### PR TITLE
STORY-884: Model Maintainer can have unit tests for enrich based on transform pipelines 

### DIFF
--- a/src/main/java/com/regnosys/rosetta/common/transform/TransformType.java
+++ b/src/main/java/com/regnosys/rosetta/common/transform/TransformType.java
@@ -9,9 +9,9 @@ package com.regnosys.rosetta.common.transform;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,14 +23,31 @@ package com.regnosys.rosetta.common.transform;
 import java.util.function.Function;
 
 public enum TransformType {
-    TRANSLATE("translate", "TBD"),
-    PROJECTION("projection", "projections.%sProjectionTabulator"),
+    PRE_TRANSLATE("translate/pre"),
+    TRANSLATE("translate"),
+    POST_TRANSLATE("translate/post"),
+
+    PRE_ENRICH("enrich/pre"),
+    ENRICH("enrich"),
+    POST_ENRICH("enrich/post"),
+
+    PRE_REPORT("regulatory-reporting/pre", "reports.%sReportTabulator", stripReportFunctionName()),
     REPORT("regulatory-reporting", "reports.%sReportTabulator", stripReportFunctionName()),
-    ENRICH("enrich", null);
+    POST_REPORT("regulatory-reporting/post", "reports.%sReportTabulator", stripReportFunctionName()),
+
+    PRE_PROJECTION("projection/pre", "projections.%sProjectionTabulator"),
+    PROJECTION("projection", "projections.%sProjectionTabulator"),
+    POST_PROJECTION("projection/post", "projections.%sProjectionTabulator");
 
     private final String resourcePath;
     private final String tabulatorName;
     private final Function<String,String> transformFunctionName;
+
+    TransformType(String resourcePath) {
+        this.resourcePath = resourcePath;
+        this.tabulatorName = "%sTabulator";
+        this.transformFunctionName = Function.identity();
+    }
 
     TransformType(String resourcePath, String tabulatorName) {
         this.resourcePath = resourcePath;


### PR DESCRIPTION
Model Maintainer can have unit tests for enrich based on transform pipelines so that enrichments can be regression tested and made available in Rosetta