### PR TITLE
task-5580: move FunctionNameHelper to rune common and tests

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/transform/EvaluateFunctionNotFoundException.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/transform/EvaluateFunctionNotFoundException.java
@@ -1,0 +1,27 @@
+package com.regnosys.rosetta.common.transform;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+public class EvaluateFunctionNotFoundException extends RuntimeException{
+    public EvaluateFunctionNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/com/regnosys/rosetta/common/transform/FunctionNameHelper.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/transform/FunctionNameHelper.java
@@ -1,0 +1,146 @@
+package com.regnosys.rosetta.common.transform;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.Iterables;
+import com.rosetta.model.lib.annotations.RosettaReport;
+import com.rosetta.model.lib.functions.RosettaFunction;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class FunctionNameHelper {
+
+    public Class<?> getInputClass(Class<? extends RosettaFunction> function) {
+        Method functionMethod = getFuncMethod(function);
+        return functionMethod.getParameterTypes()[0];
+    }
+
+    public String getInputType(Class<? extends RosettaFunction> function) {
+        return getInputClass(function).getName();
+    }
+
+    public String getOutputType(Class<? extends RosettaFunction> function) {
+        Method functionMethod = getFuncMethod(function);
+        return functionMethod.getReturnType().getName();
+    }
+
+    public Method getFuncMethod(Class<? extends RosettaFunction> function) {
+        try {
+            List<Method> evaluateMethods = Arrays.stream(function.getMethods())
+                    .filter(x -> x.getName().equals("evaluate"))
+                    .collect(Collectors.toList());
+            return Iterables.getLast(evaluateMethods);
+        } catch (Exception ex) {
+            throw new EvaluateFunctionNotFoundException("evaluate method not found in " + function.getName(), ex);
+        }
+
+    }
+
+    public String getName(Class<? extends RosettaFunction> function) {
+        return Optional.ofNullable(function.getAnnotation(com.rosetta.model.lib.annotations.RosettaReport.class))
+                .map(a -> String.format("%s / %s", a.body(), String.join(" ", a.corpusList())))
+                .orElse(readableFunctionName(function));
+    }
+
+    public String capitalizeFirstLetter(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        // Capitalize the first letter and concatenate with the rest of the string
+        return input.substring(0, 1).toUpperCase() + input.substring(1);
+    }
+
+    public String readableId(Class<? extends RosettaFunction> function) {
+        String simpleName = Optional.ofNullable(function.getAnnotation(RosettaReport.class))
+                .map(a -> String.format("%s-%s", a.body(), String.join("-", a.corpusList())))
+                .orElse(function.getSimpleName());
+
+        return readableId(simpleName);
+    }
+
+    private String readableId(String simpleName) {
+
+        String sanitise = simpleName
+                .replace("Ingest_", "")
+                .replace("Report_", "")
+                .replace("Function", "")
+                .replace("Enrich_", "")
+                .replace("Project_", "")
+                .replace("-", ".")
+                .replace("_", ".");
+
+        String functionName = lowercaseConsecutiveUppercase(sanitise)
+                .replace(".", "");
+
+        return CaseFormat.UPPER_CAMEL
+                .converterTo(CaseFormat.LOWER_HYPHEN)
+                .convert(functionName);
+    }
+
+    public String readableFunctionName(String functionSimpleName){
+        return readableFunctionNameFromId(readableId(functionSimpleName));
+    }
+
+    private String readableFunctionNameFromId(String readableId) {
+        return Arrays.stream(readableId.split("-"))
+                .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
+                .collect(Collectors.joining(" "));
+    }
+
+    private String readableFunctionName(Class<? extends RosettaFunction> function) {
+        String readableId = readableId(function);
+
+        return readableFunctionNameFromId(readableId);
+    }
+
+    private String lowercaseConsecutiveUppercase(String input) {
+        StringBuilder result = new StringBuilder();
+        boolean inUppercaseSequence = false;
+        for (int i = 0; i < input.length(); i++) {
+            char currentChar = input.charAt(i);
+            char newChar = currentChar;
+            boolean isLastChar = i == input.length() - 1;
+            if (Character.isUpperCase(currentChar)) {
+                if (!inUppercaseSequence) {
+                    // Append the first uppercase character
+                    inUppercaseSequence = true;
+                } else if (isLastChar || Character.isUpperCase(input.charAt(i + 1)) || input.charAt(i + 1) == '.') {
+                    newChar = Character.toLowerCase(currentChar);
+                    // Lowercase the middle characters
+                } else {
+                    // Append the last uppercase character
+                    inUppercaseSequence = false;
+                }
+            } else {
+                // Append lowercase or non-letter characters
+                inUppercaseSequence = false;
+            }
+            result.append(newChar);
+        }
+        return result.toString();
+    }
+
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/util/FunctionNameHelperTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/util/FunctionNameHelperTest.java
@@ -1,0 +1,122 @@
+package com.regnosys.rosetta.common.util;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+import com.regnosys.rosetta.common.transform.EvaluateFunctionNotFoundException;
+import com.regnosys.rosetta.common.transform.FunctionNameHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FunctionNameHelperTest {
+
+    private final FunctionNameHelper functionNameHelper = new FunctionNameHelper();
+
+    @Test
+    void getInputType() {
+        assertEquals("com.rosetta.model.lib.RosettaModelObject", functionNameHelper.getInputType(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void getOutputType() {
+        assertEquals("java.lang.String", functionNameHelper.getOutputType(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void getFuncMethod() {
+        assertEquals("evaluate", functionNameHelper.getFuncMethod(PipelineTestUtils.Enrich_Type_1ToType_2.class).getName());
+    }
+
+    @Test
+    void getInputTypeNoEvaluate() {
+        assertThrows(EvaluateFunctionNotFoundException.class,  () -> functionNameHelper.getInputType(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getOutputTypeNoEvaluate() {
+        assertThrows(EvaluateFunctionNotFoundException.class,  () -> functionNameHelper.getOutputType(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getFuncMethodNoEvaluate() {
+        assertThrows(EvaluateFunctionNotFoundException.class,  () -> functionNameHelper.getFuncMethod(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getNameEnrich() {
+        assertEquals("Type1 To Type2", functionNameHelper.getName(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void getNameReport() {
+        assertEquals("Type2 To Type3", functionNameHelper.getName(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getNameProjection() {
+        assertEquals("Type3 To Type4", functionNameHelper.getName(PipelineTestUtils.Project_Type_3ToType_4.class));
+    }
+
+    @Test
+    void readableIdEnrich() {
+        assertEquals("type1-to-type2", functionNameHelper.readableId(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void readableIdReport() {
+        assertEquals("type2-to-type3", functionNameHelper.readableId(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void readableIdProjection() {
+        assertEquals("type3-to-type4", functionNameHelper.readableId(PipelineTestUtils.Project_Type_3ToType_4.class));
+    }
+
+    @Test
+    void readableIdAllUpperCase() {
+        assertEquals("type2-to-type3", functionNameHelper.readableId(PipelineTestUtils.Report_TYPE_2_TO_TYPE_3.class));
+    }
+
+    @Test
+    void nameAllUpperCase() {
+        assertEquals("Type2 To Type3", functionNameHelper.getName(PipelineTestUtils.Report_TYPE_2_TO_TYPE_3.class));
+    }
+
+    @Test
+    void getNameFromId() {
+        assertEquals("Test Pack id", functionNameHelper.capitalizeFirstLetter("test Pack id"));
+    }
+
+    @Test
+    void getNameFromIdAllCaps() {
+        assertEquals("TESTPACKID", functionNameHelper.capitalizeFirstLetter("TESTPACKID"));
+    }
+
+    @Test
+    void getNameFromIdAllLowerCase() {
+        assertEquals("Test-pack-id", functionNameHelper.capitalizeFirstLetter("test-pack-id"));
+    }
+
+    @Test
+    void getReadableFunctionName(){
+        assertEquals("Type Name", functionNameHelper.readableFunctionName("Project_TypeName"));
+    }
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/util/PipelineTestUtils.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/util/PipelineTestUtils.java
@@ -1,0 +1,44 @@
+package com.regnosys.rosetta.common.util;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+import com.rosetta.model.lib.RosettaModelObject;
+import com.rosetta.model.lib.functions.RosettaFunction;
+
+public class PipelineTestUtils {
+    static class Enrich_Type_1ToType_2 implements RosettaFunction {
+        public String evaluate(RosettaModelObject input) {
+            return "Enriched" + input;
+        }
+    }
+
+    static class Report_Type_2ToType_3 implements RosettaFunction {
+    }
+
+    static class Project_Type_3ToType_4 implements RosettaFunction {
+    }
+
+    static class Report_TYPE_2_TO_TYPE_3 implements RosettaFunction {
+        public String evaluate(RosettaModelObject input) {
+            return "Enriched" + input;
+        }
+    }
+}


### PR DESCRIPTION
Please include a summary of the change and the issue/story number.

## Type of change

Story-1058: This change fixes how user-defined projection functions are seen in transform dropdowns keeping the naming consistent with model functions

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
