### PR TITLE
consistent namespace convention

### DIFF
--- a/serialization/src/test/resources/rune-serializer-error-handling-test/cardinality/cardinality.rosetta
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/cardinality/cardinality.rosetta
@@ -1,4 +1,4 @@
-namespace cardinality
+namespace serialization.test.roundtripfail.cardinality
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-error-handling-test/cardinality/too-many-elements.json
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/cardinality/too-many-elements.json
@@ -1,6 +1,6 @@
 {
-  "@model": "test.cardinality",
-  "@type": "test.cardinality.Root",
+  "@model": "serialization",
+  "@type": "serialization.test.roundtripfail.cardinality.Root",
   "@version": "0.0.0",
   "stringList": ["foo", "bar", "baz"]
 }

--- a/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/number-fraction-too-large.json
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/number-fraction-too-large.json
@@ -1,6 +1,6 @@
 {
-  "@model": "test.parameterised",
-  "@type": "test.parameterised.Root",
+  "@model": "serialization",
+  "@type": "serialization.test.roundtripfail.parameterised.Root",
   "@version": "0.0.0",
   "parameterisedNumber": 1.23456789
 }

--- a/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/number-too-large.json
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/number-too-large.json
@@ -1,6 +1,6 @@
 {
-  "@model": "test.parameterised",
-  "@type": "test.parameterised.Root",
+  "@model": "serialization",
+  "@type": "serialization.test.roundtripfail.parameterised.Root",
   "@version": "0.0.0",
   "parameterisedNumber": 123456789
 }

--- a/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/parameterised.rosetta
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/parameterised.rosetta
@@ -1,4 +1,4 @@
-namespace parameterised
+namespace serialization.test.roundtripfail.parameterised
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/string-illegal-pattern.json
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/string-illegal-pattern.json
@@ -1,6 +1,6 @@
 {
-  "@model": "test.parameterised",
-  "@type": "test.parameterised.Root",
+  "@model": "serialization",
+  "@type": "serialization.test.roundtripfail.parameterised.Root",
   "@version": "0.0.0",
   "parameterisedString": "$$"
 }

--- a/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/string-too-large.json
+++ b/serialization/src/test/resources/rune-serializer-error-handling-test/parameterised/string-too-large.json
@@ -1,6 +1,6 @@
 {
-  "@model": "test.parameterised",
-  "@type": "test.parameterised.Root",
+  "@model": "serialization",
+  "@type": "serialization.test.roundtripfail.parameterised.Root",
   "@version": "0.0.0",
   "parameterisedString": "abcdefg"
 }

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/basic/basic-types-list.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/basic/basic-types-list.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.basic.Root",
+  "@type" : "serialization.test.roundtrip.basic.Root",
   "@version" : "0.0.0",
   "basicList" : {
     "booleanTypes" : [ true, false, true ],

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/basic/basic-types-single.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/basic/basic-types-single.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.basic.Root",
+  "@type" : "serialization.test.roundtrip.basic.Root",
   "@version" : "0.0.0",
   "basicSingle" : {
     "booleanType" : true,

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/basic/basic.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/basic/basic.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.basic
+namespace serialization.test.roundtrip.basic
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-basic.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-basic.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.choicetype.Root",
+  "@type" : "serialization.test.roundtrip.choicetype.Root",
   "@version" : "0.0.0",
   "choiceBasic" : {
     "string" : "foo"

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-data.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-data.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.choicetype.Root",
+  "@type" : "serialization.test.roundtrip.choicetype.Root",
   "@version" : "0.0.0",
   "choiceData" : {
     "A" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-mixed-1.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-mixed-1.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.choicetype.Root",
+  "@type" : "serialization.test.roundtrip.choicetype.Root",
   "@version" : "0.0.0",
   "choiceMixed" : {
     "B" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-mixed-2.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-mixed-2.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.choicetype.Root",
+  "@type" : "serialization.test.roundtrip.choicetype.Root",
   "@version" : "0.0.0",
   "choiceMixed" : {
     "string" : "foo"

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.choicetype
+namespace serialization.test.roundtrip.choicetype
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/data/data-types.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/data/data-types.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.data.Root",
+  "@type" : "serialization.test.roundtrip.data.Root",
   "@version" : "0.0.0",
   "a" : {
     "b" : [ { }, {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/data/data.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/data/data.rosetta
@@ -1,5 +1,4 @@
-namespace serialization.test.data
-
+namespace serialization.test.roundtrip.data
 annotation rootType: <"Mark a type as a root of the rosetta model">
 
 type A:

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/enumtypes/enum-types-list.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/enumtypes/enum-types-list.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.enumtypes.Root",
+  "@type" : "serialization.test.roundtrip.enumtypes.Root",
   "@version" : "0.0.0",
   "enumList" : {
     "enumType" : [ "A", "B", "C", "B" ]

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/enumtypes/enum-types-single.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/enumtypes/enum-types-single.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.enumtypes.Root",
+  "@type" : "serialization.test.roundtrip.enumtypes.Root",
   "@version" : "0.0.0",
   "enumSingle" : {
     "enumType" : "A"

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/enumtypes/enum.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/enumtypes/enum.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.enumtypes
+namespace serialization.test.roundtrip.enumtypes
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/extension/base-type.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/extension/base-type.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.extension.Root",
+  "@type" : "serialization.test.roundtrip.extension.Root",
   "@version" : "0.0.0",
   "typeA" : {
     "fieldA" : "foo"

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/extension/extended-type-concrete.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/extension/extended-type-concrete.json
@@ -1,9 +1,9 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.extension.Root",
+  "@type" : "serialization.test.roundtrip.extension.Root",
   "@version" : "0.0.0",
   "typeB" : {
     "fieldB" : "foo",
-    "@type" : "serialization.test.extension.B"
+    "@type" : "serialization.test.roundtrip.extension.B"
   }
 }

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/extension/extended-type-polymorphic.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/extension/extended-type-polymorphic.json
@@ -1,10 +1,10 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.extension.Root",
+  "@type" : "serialization.test.roundtrip.extension.Root",
   "@version" : "0.0.0",
   "typeA" : {
     "fieldA" : "bar",
     "fieldB" : "foo",
-    "@type" : "serialization.test.extension.B"
+    "@type" : "serialization.test.roundtrip.extension.B"
   }
 }

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/extension/extension.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/extension/extension.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.extension
+namespace serialization.test.roundtrip.extension
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/attribute-ref.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/attribute-ref.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metakey.Root",
+  "@type" : "serialization.test.roundtrip.metakey.Root",
   "@version" : "0.0.0",
   "attributeRef" : {
     "dateField" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/dangling-attribute-ref.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/dangling-attribute-ref.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metakey.Root",
+  "@type" : "serialization.test.roundtrip.metakey.Root",
   "@version" : "0.0.0",
   "attributeRef" : {
     "dateReference" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/dangling-node-ref.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/dangling-node-ref.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metakey.Root",
+  "@type" : "serialization.test.roundtrip.metakey.Root",
   "@version" : "0.0.0",
   "nodeRef" : {
     "aReference" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/meta-key.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/meta-key.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.metakey
+namespace serialization.test.roundtrip.metakey
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/node-ref.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metakey/node-ref.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metakey.Root",
+  "@type" : "serialization.test.roundtrip.metakey.Root",
   "@version" : "0.0.0",
   "nodeRef" : {
     "typeA" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metalocation/address.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metalocation/address.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metalocation.Root",
+  "@type" : "serialization.test.roundtrip.metalocation.Root",
   "@version" : "0.0.0",
   "typeA" : {
     "b" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metalocation/dangling-address.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metalocation/dangling-address.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metalocation.Root",
+  "@type" : "serialization.test.roundtrip.metalocation.Root",
   "@version" : "0.0.0",
   "bAddress" : {
     "@ref:scoped" : "someLocation"

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metalocation/meta-location.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metalocation/meta-location.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.metalocation
+namespace serialization.test.roundtrip.metalocation
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/enum-list.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/enum-list.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metascheme.Root",
+  "@type" : "serialization.test.roundtrip.metascheme.Root",
   "@version" : "0.0.0",
   "enumTypeList" : [ {
     "@data" : "A",

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/enum-single.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/enum-single.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metascheme.Root",
+  "@type" : "serialization.test.roundtrip.metascheme.Root",
   "@version" : "0.0.0",
   "enumType" : {
     "@data" : "A",

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/meta-scheme.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/meta-scheme.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.metascheme
+namespace serialization.test.roundtrip.metascheme
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/node-list.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/node-list.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metascheme.Root",
+  "@type" : "serialization.test.roundtrip.metascheme.Root",
   "@version" : "0.0.0",
   "typeAList" : [ {
     "fieldA" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/node-single.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/metascheme/node-single.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.metascheme.Root",
+  "@type" : "serialization.test.roundtrip.metascheme.Root",
   "@version" : "0.0.0",
   "typeA" : {
     "fieldA" : {

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/record/record-types-list.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/record/record-types-list.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.record.Root",
+  "@type" : "serialization.test.roundtrip.record.Root",
   "@version" : "0.0.0",
   "recordList" : {
     "dateType" : [ "2024-12-10", "2024-11-10", "2024-10-20" ],

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/record/record-types-single.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/record/record-types-single.json
@@ -1,6 +1,6 @@
 {
   "@model" : "serialization",
-  "@type" : "serialization.test.record.Root",
+  "@type" : "serialization.test.roundtrip.record.Root",
   "@version" : "0.0.0",
   "recordSingle" : {
     "dateType" : "2024-12-10",

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/record/record.rosetta
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/record/record.rosetta
@@ -1,4 +1,4 @@
-namespace serialization.test.record
+namespace serialization.test.roundtrip.record
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 


### PR DESCRIPTION
To support serialization testing, updated the Rune name space and JSON @Type to facilitate consistent testing

- New feature (non-breaking change which adds functionality)