### PR TITLE
bug override serialisation

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/mixin/RosettaJSONAnnotationIntrospector.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/mixin/RosettaJSONAnnotationIntrospector.java
@@ -9,9 +9,9 @@ package com.regnosys.rosetta.common.serialisation.mixin;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,8 @@ import com.regnosys.rosetta.common.serialisation.mixin.legacy.LegacyRosettaBuild
 import com.rosetta.model.lib.annotations.RosettaAttribute;
 import com.rosetta.model.lib.annotations.RosettaDataType;
 
-import java.util.*;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -128,6 +129,14 @@ public class RosettaJSONAnnotationIntrospector extends JacksonAnnotationIntrospe
                 .map(m -> BeanUtil.getPropertyName(m.getAnnotated()))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean hasIgnoreMarker(AnnotatedMember a) {
+        if (a instanceof AnnotatedMethod) {
+            return !a.hasAnnotation(RosettaAttribute.class);
+        }
+        return super.hasIgnoreMarker(a);
     }
 
     @Override

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/json/RosettaSerialisationTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/json/RosettaSerialisationTest.java
@@ -173,6 +173,25 @@ public class RosettaSerialisationTest {
                 "com.rosetta.test.model.PriceQuantity");
     }
 
+    @Test
+    void overridingTypesCanDeserialize() throws JsonProcessingException {
+        ObjectMapper mapper = RosettaObjectMapper.getNewRosettaObjectMapper();
+        String rosetta =
+                "                    type A:\n" +
+                        "                b B (1..1)\n" +
+                        "            type B:\n" +
+                        "                c string (1..1)\n" +
+                        "            type BExtended extends B:\n" +
+                        "                d string (1..1)\n" +
+                        "            type AExtended extends A:\n" +
+                        "                override b BExtended (1..1)";
+
+        assertJsonSerialisation(mapper, rosetta, "{\"b\": {\"c\" : \"xxx\"}}", "com.rosetta.test.model.A");
+        assertJsonSerialisation(mapper, rosetta, "{}", "com.rosetta.test.model.AExtended");
+        assertJsonSerialisation(mapper, rosetta, "{\"b\": {\"c\" : \"xxx\"}}", "com.rosetta.test.model.AExtended");
+        assertJsonSerialisation(mapper, rosetta, "{\"b\": {\"c\" : \"xxx\", \"d\" : \"yyy\"}}", "com.rosetta.test.model.AExtended");
+    }
+
     private void assertJsonSerialisation(ObjectMapper mapper, String rosetta, String expectedJson, String fqClassName) throws JsonProcessingException {
         assertJsonSerialisation(mapper, rosetta, expectedJson, expectedJson, fqClassName);
     }


### PR DESCRIPTION
- **deprecate TransformType.getTabulatorName method (#401)**
- **Update to DSL 9.13.0 (#402)**
- **DSL Update (#404)**
- **DSL update (#405)**
- **task-4981: Add Translate 1.5 transform type (#408)**
- **Added new enums to Transform Type (#406)**
- **story 884 - Add PROJECTION_CONFIG_PATH_WITHOUT_ISO (#409)**
- **STORY-884: Fix Projection Config Path (#410)**
- **update dsl to 9.15.0 (#412)**
- **DSL update (#413)**
- **Add method to Path to remove first element (#414)**
- **Update to DSL 9.15.2 (#415)**
- **story 959 task-5025: upgrade DSL to 9.16.0 (#416)**
- **story 959 task:5023 - Fix tabulation bug - missing close bracket (#417)**
- **story 959 task-5036: type tabulator bug fix (#418)**
- **Story-957 delete old infra (#419)**
- **Update DSL to version 9.16.3 (#420)**
- **Update DSL version to 9.16.4 (#422)**
- **DSL update (#423)**
- **DSL update (#425)**
- **DSL update (#426)**
- **Update DSL version to 9.17.1 (#427)**
- **Update DSL version to 9.17.2 (#429)**
- **Improve logging (#431)**
- **Improve logging (#432)**
- **DSL update (#430)**
- **Update DSL version to 9.18.1 (#433)**
- **DSL update (#435)**
- **Update DSL to 9.20.0 (#436)**
- **Update DSL version to 9.22.0 (#438)**
- **Update TransformType.TRANSLATE path and input serialisation (#441)**
- **DSL Update (#442)**
- **Update DSL version to 9.23.1 (#443)**
- **DSL update (#444)**
- **DSL update (#445)**
- **Update RosettaObjectMapperCreator (#448)**
- **Story/1045/cdm serialization (#446)**
- **remove redundant compiler properties (#449)**
- **Update filter id (#450)**
- **add in development notice (#451)**
- **DSL update (#452)**
- **Update DSL to 9.28.2 (#453)**
- **task-5580: move FunctionNameHelper to rune common and tests (#454)**
- **DSL update (#455)**
- **DSL Update (#456)**
- **DSL patch (#457)**
- **update dsl version (#459)**
- **prevent build from pulling in broken version org.osgi.service.prefs (#460)**
- **Fix sterilization of enumerations when using Rune Serializer (#462)**
- **Update dsl version (#464)**
- **Key and Reference pruning (#463)**
- **DSL update (#466)**
- **Rune property ordering (#467)**
- **DSL update (#469)**
- **Handle top level meta headers (#468)**
- **Fix substitution groups and support unknown timezones when deserializing xsd:dateTime values (#470)**
- **Update to DSL 9.36.5 (#472)**
- **Update DSL version to 9.36.6 (#473)**
- **task-5856: updated testPack utils with an overloaded method to retrie… (#471)**
- **Xtext upgrade (#474)**
- **Revert Xtext Upgrade (#475)**
- **Update dsl 9 40 1 (#478)**
- **Better Exception handling when Initialising RosettaXMLModule (#479)**
- **DSL update (#481)**
- **STORY 1132 TASK-6024/5883: Moved Pipeline ID Formatting method to rune-common (#477)**
- **DSL update (#482)**
- **Set nexus timeout to 20 mins (#483)**
- **Add codefresh .m2 cache (#484)**
- **Update to DSL 9.42.0 (#485)**
- **Add Assertions inputPathCount and outputPathCount (#488)**
- **Model id common (#487)**
- **PathCountProcessor implementation (#489)**
- **Update to DSL 9.43.0 (#491)**
- **DSL update (#492)**
- **DSL patch (#493)**
- **Update to DSL 9.47.0 (#495)**
- **DSL update (#496)**
- **Issue-1163 refactor common code to used from Models and rosetta (#497)**
- **Only log validation report if logging enabled (#498)**
- **DSL update (#499)**
- **DSL patch (#500)**
- **Xtext Upgrade to v2.38 (#501)**
- **Fix issue for overriden types not deserialising**
