### PR TITLE
Set up Maven Central mirror to unblock Codefresh builds

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -24,7 +24,7 @@ steps:
     title: Setup Maven settings
     image: alpine/git
     commands:
-      - cf_export MVN_CLI_OPT="-Dmaven.repo.local=\"${{CF_VOLUME_PATH}}/${{CF_REPO_NAME}}_m2/repository\""
+      - cf_export MVN_CLI_OPT="-Dmaven.repo.local=\"${{CF_VOLUME_PATH}}/${{CF_REPO_NAME}}_m2/repository\" -s ${{CF_VOLUME_PATH}}/${{CF_REPO_NAME}}/settings.xml"
 
   ReleaseProperties:
     title: Setup release build
@@ -61,7 +61,7 @@ steps:
       - export CI_DEPLOY_PASSWORD="${{CI_DEPLOY_PASSWORD}}"
       - export GPG_KEYNAME="${{GPG_KEYNAME}}"
       - export GPG_PASSPHRASE="${{GPG_PASSPHRASE}}"
-      - mvn -s settings.xml -U -B ${{MVN_CLI_OPT}} clean install org.sonatype.central:central-publishing-maven-plugin:0.7.0:publish -P release
+      - mvn -B ${{MVN_CLI_OPT}} clean install org.sonatype.central:central-publishing-maven-plugin:0.7.0:publish -P release
 
   NotifySlackOnFail:
     title: Trigger Slack dev channel notification if main build failed

--- a/settings.xml
+++ b/settings.xml
@@ -1,6 +1,19 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>maven-central-proxy</id>
+            <name>Maven Central Proxy</name>
+            <url>https://europe-west1-maven.pkg.dev/production-208613/maven-central</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
     <servers>
+        <server>
+            <id>maven-central-proxy</id>
+            <username>_json_key_base64</username>
+            <password>${ARTIFACT_REGISTRY_SA_KEY}</password>
+        </server>
         <server>
             <id>ossrh</id>
             <username>${env.CI_DEPLOY_USERNAME}</username>
@@ -19,5 +32,4 @@
             </properties>
         </profile>
     </profiles>
-    <localRepository>${env.CICD_REPO}</localRepository>
 </settings>


### PR DESCRIPTION
See issue: https://github.com/finos/common-domain-model/issues/4682

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
