### PR TITLE
Fix Rune Serialiser issues (#625)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test
+
+Requires Java 21 (enforced by Maven Enforcer) and Maven. Compiles to Java 8 bytecode.
+
+```sh
+# Full build (compile + test + checkstyle)
+mvn clean install
+
+# Build without tests
+mvn clean install -DskipTests
+
+# Run tests for a single module
+mvn test -pl serialization
+mvn test -pl common
+
+# Run a single test class
+mvn test -pl serialization -Dtest=RuneJsonSerializerRoundTripTest
+mvn test -pl common -Dtest=PathTest
+
+# Run checkstyle only
+mvn checkstyle:check
+```
+
+## Architecture
+
+The project is a two-module Maven library for serializing/deserializing Rosetta Model Objects (generated from the [Rune DSL](https://github.com/finos/rune-dsl)).
+
+### Module: `serialization` (`org.finos.rune.mapper`)
+
+The **new** Rune-specific serialization layer, still under active development. Not yet production-ready — consumers should still use `RosettaObjectMapper` from `common` for now.
+
+- `RuneJsonObjectMapper` — Jackson `ObjectMapper` pre-configured for Rune DSL objects; the main entry point
+- `RuneJsonConfig` — constants for meta-property names (`@type`, `@model`, `@version`)
+- `serializer/PreProcessingSerializer` — wraps the root-level serializer; triggers `SerializationPreProcessor` before writing JSON, and adds top-level `@type`/`@model`/`@version` headers
+- `serializer/PruningDeserializer` — wraps the root-level deserializer; calls `.toBuilder().prune().build()` on the fully-deserialized object to remove empty/redundant nodes
+- `serializer/RuneChoiceTypeSerializer` / `RuneChoiceTypeDeserializer` — handles Rune choice types (union types)
+- `processor/SerializationPreProcessor` — pre-serialization pipeline: (1) collects all key types, (2) prunes duplicate references by precedence (address → external → global), (3) collects global references, (4) prunes global keys that no longer have references
+- `introspector/RuneJsonModule` — Jackson module that wires together `RuneJsonAnnotationIntrospector`, `RuneEnumBuilderIntrospector`, `PreProcessingSerializerModifier`, and `PruningDeserializerModifier`
+- `introspector/RuneStdTypeResolverBuilder` — custom polymorphic type resolver using `@type` property
+- `date/RuneDateModule` — date serialization/deserialization module
+
+### Module: `common` (`com.regnosys.rosetta.common`)
+
+The stable, production-ready library built on top of `serialization`.
+
+**Serialization** (`serialisation/`):
+- `RosettaObjectMapper` — production entry point; delegates to `RosettaObjectMapperCreator.forJSON().create()`
+- `RosettaObjectMapperCreator` — factory with format-specific builders (JSON, XML, CSV, YAML)
+- `xml/` — full XML serialization support with substitution groups, content model disambiguation, and Rosetta-specific bean serializers/deserializers
+- `mixin/legacy/` — backwards-compatible mixins for older Rosetta model versions
+
+**Hashing & References** (`hashing/`): Process steps for computing global keys, resolving references, and re-keying objects. Uses the `RosettaModelObject.process(RosettaPath, Processor)` visitor pattern.
+
+**Translation** (`translation/`): Mapping framework used during ingestion — `MappingProcessor`, `MappingContext`, `Path`. `Path` represents a dot-separated path within a source document.
+
+**Transform models** (`transform/`): `TestPackModel` and `PipelineModel` — JSON-serializable descriptors for test packs and transformation pipelines used across REGnosys tooling.
+
+**Validation** (`validation/`): `RosettaTypeValidator` validates model objects; `ValidationReport` collects results.
+
+**Other packages**: `compile/` (dynamic Java compilation), `merging/`, `postprocess/`, `projection/`, `reports/`, `testing/`, `util/`.
+
+### Code Generation in Tests
+
+The `common` module uses `rune-maven-plugin` during `generate-test-sources` to compile `.rosetta` files under `src/test/resources/rosetta/` into Java classes, which are output to `target/test-classes/serialisation/java/` and added as test sources. This means `mvn test-compile` must run before tests that depend on generated types.
+
+## Key Conventions
+
+**Dependency Injection**: Guice is used for DI. The `checkstyle-for-deprecated-guice.xml` rule (active on all builds) **forbids** `com.google.inject.Inject`, `com.google.inject.name.Named`, `com.google.inject.Provider`, and `com.google.inject.Singleton`. Use `jakarta.inject` equivalents instead.
+
+**Rosetta Model Object pattern**: All model types implement `RosettaModelObject` from `rune-runtime`. The standard pattern is immutable objects with a mutable builder: `obj.toBuilder().prune().build()`. Processing (hashing, key collection, etc.) uses the `.process(RosettaPath, Processor)` visitor.
+
+**Two serialization paths**:
+- Legacy/stable: `RosettaObjectMapper` / `RosettaObjectMapperCreator` (in `common`) — use for all current production code
+- New Rune-specific: `RuneJsonObjectMapper` (in `serialization`) — actively developed, not production-ready

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-
+.junie
 .DS_Store
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)

--- a/serialization/src/main/java/org/finos/rune/mapper/RuneJsonObjectMapper.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/RuneJsonObjectMapper.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -99,6 +101,7 @@ public class RuneJsonObjectMapper extends ObjectMapper {
                 .configure(SerializationFeature.WRITE_DATES_WITH_CONTEXT_TIME_ZONE, false)
                 .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
                 .configure(SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS, false)
+                .configure(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES, false)
                 .setFilterProvider(new SimpleFilterProvider().addFilter("SubtypeFilter", new SubtypeFilter()))
                 .addMixIn(RosettaModelObject.class, RosettaModelObjectMixin.class)
                 .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)

--- a/serialization/src/main/java/org/finos/rune/mapper/processor/collector/KeyCollectorStrategy.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/processor/collector/KeyCollectorStrategy.java
@@ -9,9 +9,9 @@ package org.finos.rune.mapper.processor.collector;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,32 +30,28 @@ import org.finos.rune.mapper.processor.pruner.ReferencePruningStrategy;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import static java.util.Optional.ofNullable;
 
 /**
  * A strategy implementation for collecting key-related information from instances of {@link RosettaModelObject}.
- * This class processes instances of {@link GlobalKey} and extracts global, external, and address keys from the
- * associated metadata, storing the corresponding values in different maps based on the type of key.
+ * For every keyed object it records how that object's keys relate to one another: which external and global key a
+ * given address key belongs to, and which global key a given external key belongs to.
  * <p>
- * The strategy creates and maintains three separate mappings:
- * <ul>
- *   <li>{@link #globalKeyToValueObjectMap}: Maps global keys to their associated values.</li>
- *   <li>{@link #externalKeyToValueObjectMap}: Maps external keys to their associated values.</li>
- *   <li>{@link #addressToValueObjectMap}: Maps address keys to their associated values.</li>
- * </ul>
- * These mappings are used by the {@link KeyLookupService} in {@link ReferencePruningStrategy} to resolve
- * references and ensure proper reference precedence during pruning operations. The collected global key information
- * is used to compare and clear redundant references based on precedence:
+ * These relationships are what the {@link KeyLookupService} exposes to {@link ReferencePruningStrategy} so it can
+ * decide that two references on the same holder are redundant - they are when the single definition identified by the
+ * higher-precedence reference also owns the lower-precedence key. Precedence runs:
  * <ol>
  *   <li>ADDRESS (highest precedence)</li>
  *   <li>EXTERNAL</li>
  *   <li>GLOBAL (lowest precedence)</li>
  * </ol>
  * <p>
- * The collected key-value mappings help ensure that only the most relevant references (higher precedence) are kept
- * while lower-precedence references pointing to the same object are removed.
+ * The maps are keyed by the address and external keys, which are unique to a definition within a document. Crucially
+ * this means a resolved/inlined copy of a reference - which carries the same global key as the genuine definition but
+ * different content, and frequently no external key at all - cannot overwrite the genuine relationship. That makes
+ * de-duplication immune to global-key collisions, so it behaves identically whether or not a reference still has its
+ * value inlined (which is what keeps serialisation idempotent across a read/write round-trip).
  * </p>
  *
  * @see RosettaModelObject
@@ -65,48 +61,45 @@ import static java.util.Optional.ofNullable;
  * @see ReferencePruningStrategy
  */
 public class KeyCollectorStrategy implements CollectorStrategy {
-    private final Map<KeyRecord, Object> globalKeyToValueObjectMap = new HashMap<>();
-    private final Map<KeyRecord, Object> externalKeyToValueObjectMap = new HashMap<>();
-    private final Map<KeyRecord, Object> addressToValueObjectMap = new HashMap<>();
+    private final Map<KeyRecord, String> addressKeyToOwnExternalKey = new HashMap<>();
+    private final Map<KeyRecord, String> addressKeyToOwnGlobalKey = new HashMap<>();
+    private final Map<KeyRecord, String> externalKeyToOwnGlobalKey = new HashMap<>();
 
     @Override
     public void collect(RosettaModelObject instance) {
         if (instance instanceof GlobalKey) {
             GlobalKey globalKey = (GlobalKey) instance;
-            Object value = getValue(instance);
             Class<?> valueClass = getValueType(instance);
-            if (value != null && valueClass != null) {
-                ofNullable(globalKey.getMeta())
-                        .map(GlobalKeyFields::getGlobalKey)
-                        .ifPresent(gk -> globalKeyToValueObjectMap.put(new KeyRecord(valueClass, gk), value));
-
-                ofNullable(globalKey.getMeta())
-                        .map(GlobalKeyFields::getExternalKey)
-                        .ifPresent(ek -> externalKeyToValueObjectMap.put(new KeyRecord(valueClass, ek), value));
-
-                ofNullable(globalKey.getMeta())
-                        .map(GlobalKeyFields::getKey)
-                        .ifPresent(keys ->
-                                keys.stream()
-                                        .map(Key::getKeyValue)
-                                        .filter(Objects::nonNull)
-                                        .forEach(kv -> addressToValueObjectMap.put(new KeyRecord(valueClass, kv), value))
-                        );
-
+            GlobalKeyFields meta = globalKey.getMeta();
+            if (valueClass == null || meta == null) {
+                return;
             }
-        }
+            String ownGlobalKey = meta.getGlobalKey();
+            String ownExternalKey = meta.getExternalKey();
 
+            if (ownExternalKey != null && ownGlobalKey != null) {
+                externalKeyToOwnGlobalKey.put(new KeyRecord(valueClass, ownExternalKey), ownGlobalKey);
+            }
+
+            ofNullable(meta.getKey()).ifPresent(keys -> {
+                for (Key key : keys) {
+                    String addressKey = key.getKeyValue();
+                    if (addressKey == null) {
+                        continue;
+                    }
+                    if (ownExternalKey != null) {
+                        addressKeyToOwnExternalKey.put(new KeyRecord(valueClass, addressKey), ownExternalKey);
+                    }
+                    if (ownGlobalKey != null) {
+                        addressKeyToOwnGlobalKey.put(new KeyRecord(valueClass, addressKey), ownGlobalKey);
+                    }
+                }
+            });
+        }
     }
 
     public KeyLookupService getKeyLookupService() {
-        return new KeyLookupService(globalKeyToValueObjectMap, externalKeyToValueObjectMap, addressToValueObjectMap);
-    }
-
-    private Object getValue(RosettaModelObject instance) {
-        if (instance instanceof FieldWithMeta) {
-            return ((FieldWithMeta<?>) instance).getValue();
-        } else
-            return instance;
+        return new KeyLookupService(addressKeyToOwnExternalKey, addressKeyToOwnGlobalKey, externalKeyToOwnGlobalKey);
     }
 
     private Class<?> getValueType(RosettaModelObject builder) {

--- a/serialization/src/main/java/org/finos/rune/mapper/processor/collector/KeyLookupService.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/processor/collector/KeyLookupService.java
@@ -9,9 +9,9 @@ package org.finos.rune.mapper.processor.collector;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,34 +23,56 @@ package org.finos.rune.mapper.processor.collector;
 import org.finos.rune.mapper.processor.KeyRecord;
 
 import java.util.Map;
+import java.util.Objects;
 
+/**
+ * Answers, for the keyed object that a higher-precedence reference resolves to, whether that same object also carries
+ * a given lower-precedence key. This is what {@code ReferencePruningStrategy} needs to decide that two references on
+ * the same holder are redundant: they are redundant precisely when the single keyed object identified by the
+ * higher-precedence (more specific, unique) key <em>also</em> owns the lower-precedence key value.
+ * <p>
+ * The lookups are keyed by the address and external keys only. Those keys are unique to a single definition within a
+ * document, so - unlike the global key, which a resolved/inlined copy can duplicate with different content - they
+ * cannot be clobbered by a redundant copy. Resolving redundancy through them, and reading the definition's own global
+ * (or external) key, is therefore immune to the global-key collisions that a value-identity comparison suffers from.
+ */
 public class KeyLookupService {
-    private final Map<KeyRecord, Object> globalKeyToValueObjectMap;
-    private final Map<KeyRecord, Object> externalKeyToValueObjectMap;
-    private final Map<KeyRecord, Object> addressToValueObjectMap;
+    private final Map<KeyRecord, String> addressKeyToOwnExternalKey;
+    private final Map<KeyRecord, String> addressKeyToOwnGlobalKey;
+    private final Map<KeyRecord, String> externalKeyToOwnGlobalKey;
 
-    public KeyLookupService(Map<KeyRecord, Object> globalKeyToValueObjectMap,
-                            Map<KeyRecord, Object> externalKeyToValueObjectMap,
-                            Map<KeyRecord, Object> addressToValueObjectMap) {
-        this.globalKeyToValueObjectMap = globalKeyToValueObjectMap;
-        this.externalKeyToValueObjectMap = externalKeyToValueObjectMap;
-        this.addressToValueObjectMap = addressToValueObjectMap;
+    public KeyLookupService(Map<KeyRecord, String> addressKeyToOwnExternalKey,
+                            Map<KeyRecord, String> addressKeyToOwnGlobalKey,
+                            Map<KeyRecord, String> externalKeyToOwnGlobalKey) {
+        this.addressKeyToOwnExternalKey = addressKeyToOwnExternalKey;
+        this.addressKeyToOwnGlobalKey = addressKeyToOwnGlobalKey;
+        this.externalKeyToOwnGlobalKey = externalKeyToOwnGlobalKey;
     }
 
-    public Object getReferencedObject(KeyType keyType, Class<?> keyOnType, String id) {
-        switch (keyType) {
-            case GLOBAL_KEY:
-                return globalKeyToValueObjectMap.get(new KeyRecord(keyOnType, id));
-            case EXTERNAL_KEY:
-                return externalKeyToValueObjectMap.get(new KeyRecord(keyOnType, id));
-            case ADDRESS:
-                return addressToValueObjectMap.get(new KeyRecord(keyOnType, id));
-            default:
-                throw new IllegalArgumentException("Unknown key type: " + keyType);
-        }
+    /**
+     * Whether the object identified by {@code addressKey} also carries {@code externalKey} as its own external key,
+     * i.e. the address and external references point to the same definition.
+     */
+    public boolean addressAndExternalShareObject(Class<?> type, String addressKey, String externalKey) {
+        return addressKey != null && externalKey != null
+                && Objects.equals(addressKeyToOwnExternalKey.get(new KeyRecord(type, addressKey)), externalKey);
     }
 
-    public enum KeyType {
-        GLOBAL_KEY, EXTERNAL_KEY, ADDRESS
+    /**
+     * Whether the object identified by {@code addressKey} also carries {@code globalKey} as its own global key,
+     * i.e. the address and global references point to the same definition.
+     */
+    public boolean addressAndGlobalShareObject(Class<?> type, String addressKey, String globalKey) {
+        return addressKey != null && globalKey != null
+                && Objects.equals(addressKeyToOwnGlobalKey.get(new KeyRecord(type, addressKey)), globalKey);
+    }
+
+    /**
+     * Whether the object identified by {@code externalKey} also carries {@code globalKey} as its own global key,
+     * i.e. the external and global references point to the same definition.
+     */
+    public boolean externalAndGlobalShareObject(Class<?> type, String externalKey, String globalKey) {
+        return externalKey != null && globalKey != null
+                && Objects.equals(externalKeyToOwnGlobalKey.get(new KeyRecord(type, externalKey)), globalKey);
     }
 }

--- a/serialization/src/main/java/org/finos/rune/mapper/processor/pruner/ReferencePruningStrategy.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/processor/pruner/ReferencePruningStrategy.java
@@ -24,19 +24,20 @@ import com.rosetta.model.lib.RosettaModelObjectBuilder;
 import com.rosetta.model.lib.meta.ReferenceWithMeta;
 import org.finos.rune.mapper.processor.collector.KeyLookupService;
 
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-
 /**
  * A pruning strategy that removes redundant references from a {@link RosettaModelObjectBuilder}.
  * This strategy checks for references of type ADDRESS, EXTERNAL, and GLOBAL, and ensures that lower-precedence
- * references are cleared if they resolve to the same object as a higher-precedence reference.
+ * references are cleared when they resolve to the same definition as a higher-precedence reference on the same holder.
  *
  * The precedence of references is as follows:
  * 1. ADDRESS (highest precedence)
  * 2. EXTERNAL
  * 3. GLOBAL (lowest precedence)
+ * <p>
+ * Two references are treated as redundant when the single keyed definition identified by the higher-precedence
+ * reference also owns the lower-precedence key. This is resolved through the {@link KeyLookupService}, which only
+ * indexes the address and external keys - keys unique to a definition - so the decision is unaffected by global-key
+ * collisions between a definition and an inlined copy of it.
  */
 public class ReferencePruningStrategy implements PruningStrategy {
     private final KeyLookupService keyLookupService;
@@ -53,45 +54,37 @@ public class ReferencePruningStrategy implements PruningStrategy {
 
         ReferenceWithMeta.ReferenceWithMetaBuilder<?> referenceWithMetaBuilder =
                 (ReferenceWithMeta.ReferenceWithMetaBuilder<?>) builder;
-        Class<?> referenceValueType = referenceWithMetaBuilder.getValueType();
+        Class<?> type = referenceWithMetaBuilder.getValueType();
 
-        Set<Object> referencedObjects = new HashSet<>();
-
-        String reference = referenceWithMetaBuilder.getReference() != null ?
+        String addressReference = referenceWithMetaBuilder.getReference() != null ?
                 referenceWithMetaBuilder.getReference().getReference() : null;
+        String externalReference = referenceWithMetaBuilder.getExternalReference();
+        String globalReference = referenceWithMetaBuilder.getGlobalReference();
 
-        addReferencedObject(referencedObjects,
-                reference,
-                KeyLookupService.KeyType.ADDRESS, referenceValueType);
-
-        if (isReferencedObjectAlreadyIncluded(referencedObjects, referenceWithMetaBuilder.getExternalReference(),
-                KeyLookupService.KeyType.EXTERNAL_KEY, referenceValueType)) {
+        // EXTERNAL is redundant when the address reference points at the same definition.
+        boolean externalRedundant = keyLookupService.addressAndExternalShareObject(type, addressReference, externalReference);
+        if (externalRedundant) {
             referenceWithMetaBuilder.setExternalReference(null);
-        } else {
-            addReferencedObject(referencedObjects, referenceWithMetaBuilder.getExternalReference(),
-                    KeyLookupService.KeyType.EXTERNAL_KEY, referenceValueType);
         }
 
-        if (isReferencedObjectAlreadyIncluded(referencedObjects, referenceWithMetaBuilder.getGlobalReference(),
-                KeyLookupService.KeyType.GLOBAL_KEY, referenceValueType)) {
+        // GLOBAL is redundant when a surviving higher-precedence reference points at the same definition: the
+        // address reference, or the external reference when it was not itself dropped as redundant.
+        boolean globalRedundant = keyLookupService.addressAndGlobalShareObject(type, addressReference, globalReference)
+                || (!externalRedundant && keyLookupService.externalAndGlobalShareObject(type, externalReference, globalReference));
+        if (globalRedundant) {
             referenceWithMetaBuilder.setGlobalReference(null);
         }
 
+        // If the reference still points to another object via any key type, the inlined value is
+        // redundant: the resolved object is serialized at its keyed location, so drop the duplicate body here.
+        if (hasReference(referenceWithMetaBuilder)) {
+            referenceWithMetaBuilder.setValue(null);
+        }
     }
 
-    private void addReferencedObject(Set<Object> referencedObjects, String reference,
-                                     KeyLookupService.KeyType keyType, Class<?> valueType) {
-        Optional<Object> referencedObject = lookupReferencedObject(keyType, valueType, reference);
-        referencedObject.ifPresent(referencedObjects::add);
-    }
-
-    private boolean isReferencedObjectAlreadyIncluded(Set<Object> referencedObjects, String reference,
-                                                      KeyLookupService.KeyType keyType, Class<?> valueType) {
-        Optional<Object> referencedObject = lookupReferencedObject(keyType, valueType, reference);
-        return referencedObject.isPresent() && referencedObjects.contains(referencedObject.get());
-    }
-
-    private Optional<Object> lookupReferencedObject(KeyLookupService.KeyType keyType, Class<?> valueType, String reference) {
-        return Optional.ofNullable(reference != null ? keyLookupService.getReferencedObject(keyType, valueType, reference) : null);
+    private boolean hasReference(ReferenceWithMeta.ReferenceWithMetaBuilder<?> builder) {
+        return builder.getGlobalReference() != null
+                || builder.getExternalReference() != null
+                || (builder.getReference() != null && builder.getReference().getReference() != null);
     }
 }

--- a/serialization/src/main/java/org/finos/rune/mapper/serializer/RuneChoiceTypeSerializer.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/serializer/RuneChoiceTypeSerializer.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.rosetta.model.lib.RosettaModelObject;
+import com.rosetta.model.lib.RosettaModelObjectBuilder;
 import com.rosetta.model.lib.annotations.RuneAttribute;
 import com.rosetta.model.lib.annotations.RuneChoiceType;
 import com.rosetta.model.lib.meta.FieldWithMeta;
@@ -105,6 +106,12 @@ public class RuneChoiceTypeSerializer extends JsonSerializer<RosettaModelObject>
             RuneAttribute attribute = method.getAnnotation(RuneAttribute.class);
             if (attribute != null
                     && method.getParameterCount() == 0
+                    // When serializing a builder, each choice option is exposed twice: by the
+                    // covariant builder getter (e.g. A.ABuilder getA()) and by the synthetic
+                    // bridge that satisfies the base interface (A getA()). Ignore the builder-typed
+                    // getter and keep the base-typed accessor, so a single option counts once and
+                    // declaredType matches the runtime built type in validateDeclaredChoiceOptionType.
+                    && !RosettaModelObjectBuilder.class.isAssignableFrom(method.getReturnType())
                     && !RuneJsonConfig.getMetaProperties().contains(attribute.value())
                     && !isChoiceMetadataAttribute(method)) {
                 Object selectedValue = invoke(method, value);

--- a/serialization/src/test/java/org/finos/rune/serialization/RuneJsonChoiceTypeSerializerTest.java
+++ b/serialization/src/test/java/org/finos/rune/serialization/RuneJsonChoiceTypeSerializerTest.java
@@ -20,6 +20,7 @@ package org.finos.rune.serialization;
  * ==============
  */
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -36,8 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.finos.rune.serialization.RuneSerializerTestHelper.*;
 
@@ -62,6 +62,116 @@ public class RuneJsonChoiceTypeSerializerTest {
     @BeforeEach
     void setUp() {
         objectMapper = newObjectMapper(dynamicCompiledClassLoader);
+    }
+
+    @Test
+    void shouldSerializeSameChoiceTypeInListWhenNotBuiltInWrapper() throws IOException {
+        RuneSerializerTestHelper.CompiledGroup group = getCompiledGroup(getGroupPath(TEST_TYPE, "list"));
+
+        RosettaModelObjectBuilder aBuilder = newBuilder(group.getType("A"));
+        invokeSetter(aBuilder, "setFieldA", "foo");
+        RosettaModelObjectBuilder choiceDataABuilder = newBuilder(group.getType("ChoiceData"));
+        invokeSetter(choiceDataABuilder, "setA", aBuilder);
+
+        RosettaModelObjectBuilder a2Builder = newBuilder(group.getType("A"));
+        invokeSetter(a2Builder, "setFieldA", "foo2");
+        RosettaModelObjectBuilder choiceDataA2Builder = newBuilder(group.getType("ChoiceData"));
+        invokeSetter(choiceDataA2Builder, "setA", a2Builder);
+
+        RosettaModelObjectBuilder economicTermsBuilder = newBuilder(group.getType("EconomicTerms"));
+        invokeSetter(economicTermsBuilder, "setPayout", Arrays.asList(choiceDataABuilder, choiceDataA2Builder));
+
+        RosettaModelObjectBuilder productBuilder = newBuilder(group.getType("Product"));
+        invokeSetter(productBuilder, "setEconomicTerms", economicTermsBuilder);
+
+        RosettaModelObjectBuilder rootBuilder = newBuilder(group.getRootType());
+        invokeSetter(rootBuilder, "setProduct", productBuilder);
+        NonRosettaWrapper wrapperWithBuilders = new NonRosettaWrapper(rootBuilder);
+
+        String builtJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(wrapperWithBuilders);
+        JsonNode payoutJson = objectMapper.readTree(builtJson)
+                .path("root")
+                .path("product")
+                .path("economicTerms")
+                .path("payout");
+
+        Assertions.assertTrue(payoutJson.isArray());
+        Assertions.assertEquals(2, payoutJson.size());
+        Assertions.assertEquals("foo", payoutJson.get(0).path("fieldA").asText());
+        Assertions.assertEquals("foo2", payoutJson.get(1).path("fieldA").asText());
+    }
+
+    @Test
+    void shouldSerializeSameChoiceTypeInListWhenNotBuiltWithoutWrapper() throws IOException {
+        RuneSerializerTestHelper.CompiledGroup group = getCompiledGroup(getGroupPath(TEST_TYPE, "list"));
+
+        RosettaModelObjectBuilder aBuilder = newBuilder(group.getType("A"));
+        invokeSetter(aBuilder, "setFieldA", "foo");
+        RosettaModelObjectBuilder choiceDataABuilder = newBuilder(group.getType("ChoiceData"));
+        invokeSetter(choiceDataABuilder, "setA", aBuilder);
+
+        RosettaModelObjectBuilder a2Builder = newBuilder(group.getType("A"));
+        invokeSetter(a2Builder, "setFieldA", "foo2");
+        RosettaModelObjectBuilder choiceDataA2Builder = newBuilder(group.getType("ChoiceData"));
+        invokeSetter(choiceDataA2Builder, "setA", a2Builder);
+
+        RosettaModelObjectBuilder economicTermsBuilder = newBuilder(group.getType("EconomicTerms"));
+        invokeSetter(economicTermsBuilder, "setPayout", Arrays.asList(choiceDataABuilder, choiceDataA2Builder));
+
+        RosettaModelObjectBuilder productBuilder = newBuilder(group.getType("Product"));
+        invokeSetter(productBuilder, "setEconomicTerms", economicTermsBuilder);
+
+        RosettaModelObjectBuilder rootBuilder = newBuilder(group.getRootType());
+        invokeSetter(rootBuilder, "setProduct", productBuilder);
+
+        String builtJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(rootBuilder);
+        JsonNode payoutJson = objectMapper.readTree(builtJson)
+                .path("product")
+                .path("economicTerms")
+                .path("payout");
+
+        Assertions.assertTrue(payoutJson.isArray());
+        Assertions.assertEquals(2, payoutJson.size());
+        Assertions.assertEquals("foo", payoutJson.get(0).path("fieldA").asText());
+        Assertions.assertEquals("foo2", payoutJson.get(1).path("fieldA").asText());
+    }
+
+    @Test
+    void shouldSerializeSameChoiceTypeInListWhenBuiltInWrapper() throws IOException {
+        RuneSerializerTestHelper.CompiledGroup group = getCompiledGroup(getGroupPath(TEST_TYPE, "list"));
+
+        RosettaModelObjectBuilder aBuilder = newBuilder(group.getType("A"));
+        invokeSetter(aBuilder, "setFieldA", "foo");
+        RosettaModelObjectBuilder choiceDataABuilder = newBuilder(group.getType("ChoiceData"));
+        invokeSetter(choiceDataABuilder, "setA", aBuilder);
+
+        RosettaModelObjectBuilder a2Builder = newBuilder(group.getType("A"));
+        invokeSetter(a2Builder, "setFieldA", "foo2");
+        RosettaModelObjectBuilder choiceDataA2Builder = newBuilder(group.getType("ChoiceData"));
+        invokeSetter(choiceDataA2Builder, "setA", a2Builder);
+
+        RosettaModelObjectBuilder economicTermsBuilder = newBuilder(group.getType("EconomicTerms"));
+        invokeSetter(economicTermsBuilder, "setPayout", Arrays.asList(choiceDataABuilder, choiceDataA2Builder));
+
+        RosettaModelObjectBuilder productBuilder = newBuilder(group.getType("Product"));
+        invokeSetter(productBuilder, "setEconomicTerms", economicTermsBuilder);
+
+        RosettaModelObjectBuilder rootBuilder = newBuilder(group.getRootType());
+        invokeSetter(rootBuilder, "setProduct", productBuilder);
+
+        RosettaModelObject builtRoot = build(rootBuilder);
+        NonRosettaWrapper wrapperWithBuiltObject = new NonRosettaWrapper(builtRoot);
+        String builtJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(wrapperWithBuiltObject);
+        JsonNode payoutJson = objectMapper.readTree(builtJson)
+                .path("root")
+                .path("product")
+                .path("economicTerms")
+                .path("payout");
+
+        Assertions.assertTrue(payoutJson.isArray());
+        Assertions.assertEquals(2, payoutJson.size());
+        Assertions.assertEquals("foo", payoutJson.get(0).path("fieldA").asText());
+        Assertions.assertEquals("foo2", payoutJson.get(1).path("fieldA").asText());
     }
 
     @Test
@@ -241,4 +351,18 @@ public class RuneJsonChoiceTypeSerializerTest {
     private String toJson(RosettaModelObject runeObject) throws JsonProcessingException {
         return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(runeObject);
     }
+
+    private static class NonRosettaWrapper {
+        @JsonProperty
+        private final RosettaModelObject root;
+
+        private NonRosettaWrapper(RosettaModelObject root) {
+            this.root = root;
+        }
+
+        public RosettaModelObject getRoot() {
+            return root;
+        }
+    }
+
 }

--- a/serialization/src/test/java/org/finos/rune/serialization/RuneSerializerPruningTest.java
+++ b/serialization/src/test/java/org/finos/rune/serialization/RuneSerializerPruningTest.java
@@ -60,6 +60,62 @@ public class RuneSerializerPruningTest {
     }
 
     @Test
+    void testGlobalKeyRefPairIsPrunedWhenExternalKeyRefAndInlinedValuePresentForMetadataKey() {
+        Path groupPath = getGroupPath(TEST_TYPE, GROUP_META_KEY);
+        Class<RosettaModelObject> rootDataType = getRootRosettaModelObjectClass(groupPath, "meta-duplicate-refs.rosetta");
+        String input = readAsString(getFile(groupPath, "global-and-external-key-with-inlined-body-input.json"));
+
+        RosettaModelObject deserializedObject = fromJson(objectMapper, input, rootDataType);
+        String result = toJson(objectMapper, deserializedObject);
+
+        String expected = readAsString(getFile(groupPath, "global-and-external-key-with-inlined-body-expected.json"));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testGlobalKeyRefPairIsPrunedWhenDuplicateKeyIsNestedDeepInInlinedBody() {
+        Path groupPath = getGroupPath(TEST_TYPE, GROUP_META_KEY);
+        Class<RosettaModelObject> rootDataType = getRootRosettaModelObjectClass(groupPath, "meta-duplicate-refs.rosetta");
+        String input = readAsString(getFile(groupPath, "deep-nested-key-in-inlined-body-input.json"));
+
+        RosettaModelObject deserializedObject = fromJson(objectMapper, input, rootDataType);
+        String result = toJson(objectMapper, deserializedObject);
+
+        String expected = readAsString(getFile(groupPath, "deep-nested-key-in-inlined-body-expected.json"));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testGlobalKeyRefPairIsPrunedWhenAnotherObjectSharesTheSameGlobalKey() {
+        Path groupPath = getGroupPath(TEST_TYPE, GROUP_META_KEY);
+        Class<RosettaModelObject> rootDataType = getRootRosettaModelObjectClass(groupPath, "meta-duplicate-refs.rosetta");
+        String input = readAsString(getFile(groupPath, "global-ref-pruned-when-another-object-shares-global-key-input.json"));
+
+        RosettaModelObject deserializedObject = fromJson(objectMapper, input, rootDataType);
+        String result = toJson(objectMapper, deserializedObject);
+
+        String expected = readAsString(getFile(groupPath, "global-ref-pruned-when-another-object-shares-global-key-expected.json"));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testReferenceWithInlinedBodyIsPrunedWhenSiblingKeyedBodyExists() {
+        Path groupPath = getGroupPath(TEST_TYPE, GROUP_OBJECT_PRUNING);
+        Class<RosettaModelObject> rootDataType = getRootRosettaModelObjectClass(groupPath, "object-prune.rosetta");
+        String input = readAsString(getFile(groupPath, "reference-with-inlined-body-input.json"));
+
+        RosettaModelObject deserializedObject = fromJson(objectMapper, input, rootDataType);
+        String result = toJson(objectMapper, deserializedObject);
+
+        String expected = readAsString(getFile(groupPath, "reference-with-inlined-body-expected.json"));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     void testStringWithEmptyMetaPrunesOnDeserialise() throws NoSuchFieldException, IllegalAccessException {
         Path groupPath = getGroupPath(TEST_TYPE, GROUP_OBJECT_PRUNING);
         Class<RosettaModelObject> rootDataType = getRootRosettaModelObjectClass(groupPath, "object-prune.rosetta");

--- a/serialization/src/test/resources/rune-json-choice-type-serializer-test/list/choice.rosetta
+++ b/serialization/src/test/resources/rune-json-choice-type-serializer-test/list/choice.rosetta
@@ -1,0 +1,23 @@
+namespace serialization.test.passing.list
+
+annotation rootType: <"Mark a type as a root of the rosetta model">
+
+type A:
+  fieldA string (1..1)
+
+type B:
+  fieldB string (1..1)
+
+choice ChoiceData:
+  A
+  B
+
+type EconomicTerms:
+  payout ChoiceData (0..*)
+
+type Product:
+  economicTerms EconomicTerms (1..1)
+
+type Root:
+  [rootType]
+  product Product (1..1)

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/deep-nested-key-in-inlined-body-expected.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/deep-nested-key-in-inlined-body-expected.json
@@ -1,0 +1,15 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.metakey.Root",
+  "@version" : "0.0.0",
+  "objectRefs" : [ {
+    "someField" : "objectRef",
+    "keyedThing" : {
+      "@key:external" : "objExternalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref:external" : "objExternalKey1"
+    }
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/deep-nested-key-in-inlined-body-input.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/deep-nested-key-in-inlined-body-input.json
@@ -1,0 +1,22 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.metakey.Root",
+  "@version" : "0.0.0",
+  "objectRefs" : [ {
+    "someField" : "objectRef",
+    "keyedThing" : {
+      "@key" : "objKey1",
+      "@key:external" : "objExternalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref" : "objKey1",
+      "@ref:external" : "objExternalKey1",
+      "name" : "thing-1",
+      "nested" : {
+        "@key" : "objKey1",
+        "name" : "nested-thing"
+      }
+    }
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-and-external-key-with-inlined-body-expected.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-and-external-key-with-inlined-body-expected.json
@@ -1,0 +1,15 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.metakey.Root",
+  "@version" : "0.0.0",
+  "objectRefs" : [ {
+    "someField" : "objectRef",
+    "keyedThing" : {
+      "@key:external" : "objExternalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref:external" : "objExternalKey1"
+    }
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-and-external-key-with-inlined-body-input.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-and-external-key-with-inlined-body-input.json
@@ -1,0 +1,19 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.metakey.Root",
+  "@version" : "0.0.0",
+  "objectRefs" : [ {
+    "someField" : "objectRef",
+    "keyedThing" : {
+      "@key" : "objKey1",
+      "@key:external" : "objExternalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref" : "objKey1",
+      "@ref:external" : "objExternalKey1",
+      "@key" : "objKey1",
+      "name" : "thing-1"
+    }
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-ref-pruned-when-another-object-shares-global-key-expected.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-ref-pruned-when-another-object-shares-global-key-expected.json
@@ -1,0 +1,20 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.metakey.Root",
+  "@version" : "0.0.0",
+  "objectRefs" : [ {
+    "someField" : "definition",
+    "keyedThing" : {
+      "@key:external" : "externalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref:external" : "externalKey1"
+    }
+  }, {
+    "someField" : "collision",
+    "keyedThing" : {
+      "name" : "thing-2"
+    }
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-ref-pruned-when-another-object-shares-global-key-input.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/global-ref-pruned-when-another-object-shares-global-key-input.json
@@ -1,0 +1,23 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.metakey.Root",
+  "@version" : "0.0.0",
+  "objectRefs" : [ {
+    "someField" : "definition",
+    "keyedThing" : {
+      "@key" : "sharedGlobalKey",
+      "@key:external" : "externalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref" : "sharedGlobalKey",
+      "@ref:external" : "externalKey1"
+    }
+  }, {
+    "someField" : "collision",
+    "keyedThing" : {
+      "@key" : "sharedGlobalKey",
+      "name" : "thing-2"
+    }
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/meta-duplicate-refs.rosetta
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/meta-duplicate-refs.rosetta
@@ -11,6 +11,18 @@ type AttributeRef:
     [metadata reference]
     [metadata address "pointsTo"=AttributeRef->dateField]
 
+type KeyedThing:
+  [metadata key]
+  name string (1..1)
+  nested KeyedThing (0..1)
+
+type ObjectRef:
+  someField string (1..1)
+  keyedThing KeyedThing (0..1)
+  keyedThingReference KeyedThing (0..1)
+    [metadata reference]
+
 type Root:
   [rootType]
   attributeRefs AttributeRef (0..*)
+  objectRefs ObjectRef (0..*)

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/node-key-with-duplicate-ref-expected.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/node-key-with-duplicate-ref-expected.json
@@ -49,5 +49,33 @@
     "dateReference" : {
       "@ref" : "someKey5"
     }
+  } ],
+  "objectRefs" : [ {
+    "someField" : "bar1",
+    "keyedThing" : {
+      "@key:external" : "objExternalKey1",
+      "name" : "thing-1"
+    },
+    "keyedThingReference" : {
+      "@ref:external" : "objExternalKey1"
+    }
+  }, {
+    "someField" : "bar2",
+    "keyedThing" : {
+      "@key:scoped" : "objScopedKey2",
+      "name" : "thing-2"
+    },
+    "keyedThingReference" : {
+      "@ref:scoped" : "objScopedKey2"
+    }
+  }, {
+    "someField" : "bar3",
+    "keyedThing" : {
+      "@key" : "objKey3",
+      "name" : "thing-3"
+    },
+    "keyedThingReference" : {
+      "@ref" : "objKey3"
+    }
   } ]
 }

--- a/serialization/src/test/resources/rune-serializer-pruning-test/metakey/node-key-with-duplicate-ref-input.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/metakey/node-key-with-duplicate-ref-input.json
@@ -63,5 +63,45 @@
         "@ref": "someKey5"
       }
     }
+  ],
+  "objectRefs": [
+    {
+      "someField" : "bar1",
+      "keyedThing": {
+        "@key": "objKey1",
+        "@key:external": "objExternalKey1",
+        "name": "thing-1"
+      },
+      "keyedThingReference": {
+        "@ref": "objKey1",
+        "@ref:external": "objExternalKey1",
+        "@key": "objKey1",
+        "name": "thing-1"
+      }
+    },
+    {
+      "someField" : "bar2",
+      "keyedThing": {
+        "@key": "objKey2",
+        "@key:scoped": "objScopedKey2",
+        "name": "thing-2"
+      },
+      "keyedThingReference": {
+        "@ref": "objKey2",
+        "@ref:scoped": "objScopedKey2",
+        "@key": "objKey2",
+        "name": "thing-2"
+      }
+    },
+    {
+      "someField" : "bar3",
+      "keyedThing": {
+        "@key": "objKey3",
+        "name": "thing-3"
+      },
+      "keyedThingReference": {
+        "@ref": "objKey3"
+      }
+    }
   ]
 }

--- a/serialization/src/test/resources/rune-serializer-pruning-test/objectprune/object-prune.rosetta
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/objectprune/object-prune.rosetta
@@ -2,7 +2,17 @@ namespace serialization.test.passing.objectprune
 
 annotation rootType: <"Mark a type as a root of the rosetta model">
 
+type Party:
+  [metadata key]
+  name string (1..1)
+
+type Counterparty:
+  partyReference Party (1..1)
+    [metadata reference]
+
 type Root:
   [rootType]
-  fieldA string (1..1)
+  fieldA string (0..1)
     [metadata scheme]
+  counterparty Counterparty (0..*)
+  party Party (0..*)

--- a/serialization/src/test/resources/rune-serializer-pruning-test/objectprune/reference-with-inlined-body-expected.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/objectprune/reference-with-inlined-body-expected.json
@@ -1,0 +1,14 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.objectprune.Root",
+  "@version" : "0.0.0",
+  "counterparty" : [ {
+    "partyReference" : {
+      "@ref:external" : "party2"
+    }
+  } ],
+  "party" : [ {
+    "@key:external" : "party2",
+    "name" : "Bank Y"
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-pruning-test/objectprune/reference-with-inlined-body-input.json
+++ b/serialization/src/test/resources/rune-serializer-pruning-test/objectprune/reference-with-inlined-body-input.json
@@ -1,0 +1,16 @@
+{
+  "@model" : "serialization",
+  "@type" : "serialization.test.passing.objectprune.Root",
+  "@version" : "0.0.0",
+  "counterparty" : [ {
+    "partyReference" : {
+      "@ref:external" : "party2",
+      "@key:external" : "party2",
+      "name" : "Bank Y"
+    }
+  } ],
+  "party" : [ {
+    "@key:external" : "party2",
+    "name" : "Bank Y"
+  } ]
+}

--- a/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-data-list.json
+++ b/serialization/src/test/resources/rune-serializer-round-trip-test/choicetype/choice-data-list.json
@@ -8,5 +8,8 @@
   }, {
     "@type" : "serialization.test.passing.choicetype.B",
     "fieldB" : "foo"
+  }, {
+    "@type" : "serialization.test.passing.choicetype.A",
+    "fieldA" : "foo2"
   } ]
 }


### PR DESCRIPTION
# This PR addressed the following issues

## Fix: `RuneChoiceTypeSerializer` fails when serializing `RosettaModelObjectBuilder` types

`RuneChoiceTypeSerializer` discovers the populated choice option by reflecting over `@RuneAttribute` annotated getters. When serializing a builder, each option appears twice: once as the covariant builder-typed override and once as the bridge method satisfying the base interface, both carrying the annotation. This caused the serializer to count the same option twice, breaking declared-type validation.

This only manifests when the root is a non-Rosetta wrapper — when a `RosettaModelObject` is at the root, `PreProcessingSerializer` converts it via `toBuilder().build()` before any inner serializer runs.

The fix skips `@RuneAttribute` getters whose return type is assignable to `RosettaModelObjectBuilder`.

## Fix: prune inlined value body from `ReferenceWithMeta` when a reference key is present

The old `RosettaObjectMapper` suppressed the inlined `value` body of a `ReferenceWithMeta` via
a Jackson property filter whenever a reference key was set, ensuring the resolved object was not
duplicated inline at every usage site. The new `RuneJsonObjectMapper` was missing this behaviour
entirely.

The fix adds this to `ReferencePruningStrategy`: after de-duplicating reference keys, if any
reference (global, external, or address) remains, the inlined `value` is cleared on the builder
before serialization.

## Fix: redundant lower-precedence `@ref`/`@key` pairs not pruned when inlined body carries a duplicate key

When a `ReferenceWithMeta` holder carried both a higher-precedence reference (e.g. `@ref:external`) and a lower-precedence one (e.g. `@ref`), the lower-precedence pair should be pruned. This was broken because the key lookup was implemented as a map from global key to object instance. An inlined body — which shares its global key with the canonical definition it copies — would overwrite the canonical entry last-write-wins, causing the redundancy check to compare against the wrong object and leave the lower-precedence `@ref`/`@key` in place. The same collision also caused idempotency failures: round-tripping an object would yield different output depending on whether the inlined body was present.

The fix redesigns the key lookup to record co-ownership relationships between key types on the same definition, indexed by address and external keys (which are unique per definition and cannot be clobbered by an inlined copy). The redundancy check asks "does the definition identified by the higher-precedence reference also own the lower-precedence key?" — a question the address/external-keyed maps answer reliably regardless of global-key collisions. Key collection traverses every node unconditionally; no traversal-skipping is required.

## Fix:  preserve trailing zeros on serialised output

The serialiser was previously stripping trailing zeros when deserialising into a BigDecimal, meaning any deserialise to serialise journey would strip trailing zeros. This did not match expected behaviour.