### PR TITLE
Bump rune-dsl to 10.0.0-dev.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>8</maven.compiler.release>
-        <rune.dsl.version>10.0.0-dev.17</rune.dsl.version>
+        <rune.dsl.version>10.0.0-dev.20</rune.dsl.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>

--- a/serialization/src/test/java/org/finos/rune/serialization/RuneSerializerTestHelper.java
+++ b/serialization/src/test/java/org/finos/rune/serialization/RuneSerializerTestHelper.java
@@ -29,9 +29,9 @@ import com.google.inject.Module;
 import com.google.inject.util.Modules;
 import com.regnosys.rosetta.RosettaRuntimeModule;
 import com.regnosys.rosetta.RosettaStandaloneSetup;
-import com.regnosys.rosetta.config.RosettaConfiguration;
-import com.regnosys.rosetta.config.RosettaGeneratorsConfiguration;
-import com.regnosys.rosetta.config.RosettaModelConfiguration;
+import com.regnosys.rosetta.config.RuneConfiguration;
+import com.regnosys.rosetta.config.RuneGeneratorsConfiguration;
+import com.regnosys.rosetta.config.RuneModelConfiguration;
 import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper;
 import com.rosetta.model.lib.RosettaModelObject;
 import com.rosetta.model.lib.RosettaModelObjectBuilder;
@@ -263,10 +263,10 @@ public class RuneSerializerTestHelper {
         Module module = Modules.override(new RosettaRuntimeModule()).with(new AbstractModule() {
             @Override
             protected void configure() {
-                bind(RosettaConfiguration.class).toInstance(new RosettaConfiguration(
-                        new RosettaModelConfiguration(TEST_MODEL_NAME, Collections.emptyList()),
+                bind(RuneConfiguration.class).toInstance(new RuneConfiguration(
+                        new RuneModelConfiguration(TEST_MODEL_NAME, Collections.emptyList()),
                         new ArrayList<>(),
-                        new RosettaGeneratorsConfiguration()
+                        new RuneGeneratorsConfiguration()
                 ));
             }
         });


### PR DESCRIPTION
Bumps `rune.dsl.version` to `10.0.0-dev.20`.

## Why
Moves the bundle to dev.20. The incompatible config API change was introduced in **dev.18** — the `Rosetta*Configuration` config classes were renamed to `Rune*` and moved from rune-lang to rune-runtime (package `com.regnosys.rosetta.config` unchanged). dev.19 and dev.20 are backwards-compatible patches on top of dev.18.

## Changes
- `pom.xml`: `rune.dsl.version` -> 10.0.0-dev.20
- `RuneSerializerTestHelper`: `RosettaConfiguration` -> `RuneConfiguration`, `RosettaModelConfiguration` -> `RuneModelConfiguration`, `RosettaGeneratorsConfiguration` -> `RuneGeneratorsConfiguration` (the 3-arg `RuneConfiguration` constructor is unchanged).

Minimal compat-only patch. No feature work. Builds green (default and `-Prelease -Dgpg.skip=true`).
