### PR TITLE
[11.x.x] - XMLContentModelMatcher Zero Width Optional Content Fix

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcher.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcher.java
@@ -148,9 +148,12 @@ final class XMLContentModelMatcher {
         }
         List<MatchResult> singles = matchOnce(node, inputs, inputIndex, pushed);
         for (MatchResult one : singles) {
-            // Must consume at least one input or it would loop forever; allow zero-consumption only
-            // if min<=count already (handled by the early return on count==min above), and skip here.
-            if (one.nextIndex == inputIndex && one.assignments.isEmpty()) {
+            // A zero-width iteration (matches without consuming input, e.g. a compound node whose
+            // children are all optional and absent) is only redundant once min is already satisfied
+            // by prior iterations - repeating it further would recurse forever without ever advancing
+            // nextIndex. Below min, it must be allowed through so the required occurrence count can
+            // still be reached via a legitimately empty match.
+            if (one.nextIndex == inputIndex && one.assignments.isEmpty() && count >= min) {
                 continue;
             }
             List<Assignment> merged = concat(accumulated, one.assignments);

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherOptionalChoiceInSequenceTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherOptionalChoiceInSequenceTest.java
@@ -1,0 +1,119 @@
+package com.regnosys.rosetta.common.serialisation.xml.deserialization;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2026 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============
+ */
+
+import com.regnosys.rosetta.common.serialisation.xml.config.OccursMax;
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModel;
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModelNodeType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces a bug in {@link XMLContentModelMatcher#repeat}: a {@code SEQUENCE} node with
+ * {@code minOccurs=1} whose only child is an already-optional {@code CHOICE} node
+ * ({@code minOccurs=0}) is incorrectly rejected as {@code NO_MATCH} when none of the choice's
+ * branches are present in the input, even though this is a structurally valid, fully-optional
+ * content model (the XML Schema equivalent of
+ * {@code <xs:sequence><xs:choice minOccurs="0">...</xs:choice></xs:sequence>}).
+ *
+ * <p>This is the exact shape generated for Rosetta types such as {@code TradeIdentifier}, whose
+ * top-level content model is a mandatory {@code SEQUENCE} wrapping a single optional
+ * {@code CHOICE} of {@code issuer+tradeId} or {@code partyReference(+accountReference,tradeId*)}.
+ * When an instance of such a type (or a subtype with additional, unrelated appended fields) has
+ * none of the choice's own elements present, {@link XMLContentModelMatcher#route} returns
+ * {@code NO_MATCH} instead of {@code SUCCESS}.</p>
+ */
+class XMLContentModelMatcherOptionalChoiceInSequenceTest {
+
+    @Test
+    void sequenceWithSoleOptionalChoiceIsSatisfiedByZeroMatchingInputs() {
+        // SEQUENCE(minOccurs=1, maxOccurs=1) -> [ CHOICE(minOccurs=0, maxOccurs=1) -> [fieldA, fieldB] ]
+        XMLContentModel model = sequenceOnce(
+                optionalChoice(
+                        element("fieldA", "fieldA"),
+                        element("fieldB", "fieldB")));
+
+        // No input elements at all: the choice legitimately matches zero times (it is optional),
+        // so the enclosing sequence's single, empty-content occurrence should satisfy its own
+        // minOccurs=1 and the whole document should be reported as a successful (empty) match.
+        XMLContentModelMatcher.RoutingResult result = XMLContentModelMatcher.route(model, Collections.emptyList());
+
+        assertEquals(XMLContentModelMatcher.RoutingResult.Status.SUCCESS, result.getStatus());
+    }
+
+    @Test
+    void sequenceWithSoleOptionalChoiceStillRoutesWhenAChoiceBranchIsPresent() {
+        // Sanity check: the same content model correctly routes when one of the choice's own
+        // elements actually is present, confirming the bug is specific to the zero-element case.
+        XMLContentModel model = sequenceOnce(
+                optionalChoice(
+                        element("fieldA", "fieldA"),
+                        element("fieldB", "fieldB")));
+
+        XMLContentModelMatcher.RoutingResult result = XMLContentModelMatcher.route(model,
+                Collections.singletonList(input("fieldA")));
+
+        assertEquals(XMLContentModelMatcher.RoutingResult.Status.SUCCESS, result.getStatus());
+        assertEquals(Collections.singletonList("fieldA"), result.getPathByIndex().get(0));
+    }
+
+    private static RoutingInput input(String xmlName) {
+        return new RoutingInput(0, xmlName, RoutingInput.Namespace.unknown());
+    }
+
+    private static XMLContentModel element(String xmlName, String path) {
+        return new XMLContentModel(
+                XMLContentModelNodeType.ELEMENT,
+                Optional.of(xmlName),
+                Optional.empty(),
+                Optional.of(Collections.singletonList(path)),
+                Optional.of(1),
+                Optional.of(OccursMax.of(1)),
+                Optional.empty());
+    }
+
+    private static XMLContentModel optionalChoice(XMLContentModel... children) {
+        return new XMLContentModel(
+                XMLContentModelNodeType.CHOICE,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(0),
+                Optional.of(OccursMax.of(1)),
+                Optional.of(Arrays.asList(children)));
+    }
+
+    private static XMLContentModel sequenceOnce(XMLContentModel... children) {
+        return new XMLContentModel(
+                XMLContentModelNodeType.SEQUENCE,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(1),
+                Optional.of(OccursMax.of(1)),
+                Optional.of(Arrays.asList(children)));
+    }
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherZeroWidthOptionalContentTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherZeroWidthOptionalContentTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Reproduces a bug in {@code XMLContentModelMatcher#repeat}: a {@code SEQUENCE} node with
- * {@code minOccurs=1} whose only child is an already-optional {@code CHOICE} node
+ * {@code minOccurs=1} whose only child is an already optional {@code CHOICE} node
  * ({@code minOccurs=0}) is incorrectly rejected as {@code NO_MATCH} when none of the choice's
  * branches are present in the input, even though this is a structurally valid, fully optional
  * content model (the XML Schema equivalent of

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherZeroWidthOptionalContentTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherZeroWidthOptionalContentTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Reproduces a bug in {@code XMLContentModelMatcher#repeat}: a {@code SEQUENCE} node with
  * {@code minOccurs=1} whose only child is an already-optional {@code CHOICE} node
  * ({@code minOccurs=0}) is incorrectly rejected as {@code NO_MATCH} when none of the choice's
- * branches are present in the input, even though this is a structurally valid, fully-optional
+ * branches are present in the input, even though this is a structurally valid, fully optional
  * content model (the XML Schema equivalent of
  * {@code <xs:sequence><xs:choice minOccurs="0">...</xs:choice></xs:sequence>}).
  *

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherZeroWidthOptionalContentTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelMatcherZeroWidthOptionalContentTest.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Reproduces a bug in {@link XMLContentModelMatcher#repeat}: a {@code SEQUENCE} node with
+ * Reproduces a bug in {@code XMLContentModelMatcher#repeat}: a {@code SEQUENCE} node with
  * {@code minOccurs=1} whose only child is an already-optional {@code CHOICE} node
  * ({@code minOccurs=0}) is incorrectly rejected as {@code NO_MATCH} when none of the choice's
  * branches are present in the input, even though this is a structurally valid, fully-optional
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * none of the choice's own elements present, {@link XMLContentModelMatcher#route} returns
  * {@code NO_MATCH} instead of {@code SUCCESS}.</p>
  */
-class XMLContentModelMatcherOptionalChoiceInSequenceTest {
+class XMLContentModelMatcherZeroWidthOptionalContentTest {
 
     @Test
     void sequenceWithSoleOptionalChoiceIsSatisfiedByZeroMatchingInputs() {


### PR DESCRIPTION
### Summary

Fixes `XMLContentModelMatcher.route()` incorrectly returning `NO_MATCH` for a content model shaped as `SEQUENCE(minOccurs=1)` whose sole child is an already-optional `CHOICE(minOccurs=0)`, when none of the choice's branches are present in the input.

This is a structurally valid, fully-optional content model - the equivalent of `<xs:sequence><xs:choice minOccurs="0">...</xs:choice></xs:sequence>` - and is exactly the shape generated for Rosetta types such as `fpml.consolidated.doc.TradeIdentifier`. In real-world usage this surfaced as a `JsonMappingException: Cannot route XML content for ...` deserialization failure whenever such a type has none of the choice's own fields set (e.g. only unrelated, appended sibling fields present).

### Root cause

`XMLContentModelMatcher.repeat()` had an anti-infinite-loop guard that discarded any zero-consumption match before it could be counted toward the enclosing node's own `minOccurs`. This is correct for preventing infinite recursion, but incorrectly rejected the legitimate case of a single zero-consumption match satisfying `minOccurs=1` for a sequence whose only child is itself optional.

### What's included

- `XMLContentModelMatcherOptionalChoiceInSequenceTest`:
  - `sequenceWithSoleOptionalChoiceIsSatisfiedByZeroMatchingInputs` - reproduces the bug: asserts `route()` returns `SUCCESS` for zero matching inputs.
  - `sequenceWithSoleOptionalChoiceStillRoutesWhenAChoiceBranchIsPresent` - sanity check confirming the same content model still routes correctly when a choice branch *is* present.
- Fix in `XMLContentModelMatcher.repeat()`: a zero-width iteration is now still counted toward the enclosing node's `minOccurs` when the min constraint is otherwise satisfied, instead of being unconditionally discarded.

Fixes #655
