### PR TITLE
[11.x.x] - Support LabelProvider based CSV deserialisation

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaCsvMapper.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaCsvMapper.java
@@ -100,17 +100,21 @@ public class RosettaCsvMapper extends CsvMapper  {
     private CsvSchema buildLabelReadSchema(Class<?> valueType, List<String> headerLabels) {
         CsvSchema schema = schemaFor(valueType);
         Map<String, String> labelToAttribute = new HashMap<>();
+        boolean ambiguousLabels = false;
         for (CsvSchema.Column column : schema) {
             String attribute = column.getName();
             String label = labelProvider.getLabel(RosettaPath.valueOf(attribute));
             String key = label != null ? label : attribute;
             String previous = labelToAttribute.putIfAbsent(key, attribute);
             if (previous != null) {
-                throw new IllegalStateException(
-                        String.format("Duplicate label '%s' shared by attributes '%s' and '%s': "
-                                        + "cannot unambiguously deserialise labelled CSV",
-                                key, previous, attribute));
+                // Two attributes share a label, so the header text cannot be resolved to a
+                // single attribute. Fall back to positional binding against the canonical
+                // schema order, which is the order the writer always emits columns in.
+                ambiguousLabels = true;
             }
+        }
+        if (ambiguousLabels) {
+            return buildPositionalReadSchema(valueType, schema, headerLabels);
         }
         CsvSchema.Builder builder = CsvSchema.builder();
         Set<String> consumed = new HashSet<>();
@@ -128,6 +132,26 @@ public class RosettaCsvMapper extends CsvMapper  {
                                 headerLabel, attribute));
             }
             builder.addColumn(attribute);
+        }
+        return builder.build().withSkipFirstDataRow(true);
+    }
+
+    /**
+     * Binds columns by position against the type's canonical schema order rather than by
+     * label name. Used only when duplicate labels make name-based binding impossible.
+     * Requires the header column count to match the schema so that a structurally unexpected
+     * file (e.g. reordered or truncated) fails fast rather than silently mis-mapping columns.
+     */
+    private CsvSchema buildPositionalReadSchema(Class<?> valueType, CsvSchema schema, List<String> headerLabels) {
+        if (headerLabels.size() != schema.size()) {
+            throw new IllegalStateException(
+                    String.format("Ambiguous labels force positional binding for %s, but the header has "
+                                    + "%d column(s) while the type has %d: cannot safely map columns by position",
+                            valueType.getName(), headerLabels.size(), schema.size()));
+        }
+        CsvSchema.Builder builder = CsvSchema.builder();
+        for (CsvSchema.Column column : schema) {
+            builder.addColumn(column.getName());
         }
         return builder.build().withSkipFirstDataRow(true);
     }

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaCsvMapper.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaCsvMapper.java
@@ -22,18 +22,27 @@ package com.regnosys.rosetta.common.serialisation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.rosetta.model.lib.functions.LabelProvider;
 import com.rosetta.model.lib.path.RosettaPath;
+import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class RosettaCsvMapper extends CsvMapper  {
     private final CsvSchema defaultSchema;
@@ -51,7 +60,12 @@ public class RosettaCsvMapper extends CsvMapper  {
     @Override
     public <T> T readValue(String content, Class<T> valueType) throws JsonMappingException {
         try {
-            return super.readerFor(valueType).with(defaultSchema).readValue(content, valueType);
+            if (labelProvider == null) {
+                return super.readerFor(valueType).with(defaultSchema).readValue(content, valueType);
+            }
+            List<String> headerLabels = readHeaderLabels(content);
+            CsvSchema labelReadSchema = buildLabelReadSchema(valueType, headerLabels);
+            return super.readerFor(valueType).with(labelReadSchema).readValue(content, valueType);
         } catch (IOException e) {
             throw  new JsonMappingException(null,
                     String.format("IOException (of type %s): %s",
@@ -62,7 +76,60 @@ public class RosettaCsvMapper extends CsvMapper  {
 
     @Override
     public <T> T readValue(URL src, Class<T> valueType) throws IOException {
-        return super.readerFor(valueType).with(defaultSchema).readValue(src, valueType);
+        if (labelProvider == null) {
+            return super.readerFor(valueType).with(defaultSchema).readValue(src, valueType);
+        }
+        String content = IOUtils.toString(src, StandardCharsets.UTF_8);
+        List<String> headerLabels = readHeaderLabels(content);
+        CsvSchema labelReadSchema = buildLabelReadSchema(valueType, headerLabels);
+        return super.readerFor(valueType).with(labelReadSchema).readValue(content, valueType);
+    }
+
+    private List<String> readHeaderLabels(String content) throws IOException {
+        try (MappingIterator<String[]> rows = super.readerFor(String[].class)
+                .with(CsvSchema.emptySchema())
+                .with(CsvParser.Feature.WRAP_AS_ARRAY)
+                .readValues(content)) {
+            if (!rows.hasNext()) {
+                throw new IllegalStateException("Cannot deserialise labelled CSV: missing header row");
+            }
+            return Arrays.asList(rows.nextValue());
+        }
+    }
+
+    private CsvSchema buildLabelReadSchema(Class<?> valueType, List<String> headerLabels) {
+        CsvSchema schema = schemaFor(valueType);
+        Map<String, String> labelToAttribute = new HashMap<>();
+        for (CsvSchema.Column column : schema) {
+            String attribute = column.getName();
+            String label = labelProvider.getLabel(RosettaPath.valueOf(attribute));
+            String key = label != null ? label : attribute;
+            String previous = labelToAttribute.putIfAbsent(key, attribute);
+            if (previous != null) {
+                throw new IllegalStateException(
+                        String.format("Duplicate label '%s' shared by attributes '%s' and '%s': "
+                                        + "cannot unambiguously deserialise labelled CSV",
+                                key, previous, attribute));
+            }
+        }
+        CsvSchema.Builder builder = CsvSchema.builder();
+        Set<String> consumed = new HashSet<>();
+        for (String headerLabel : headerLabels) {
+            String attribute = labelToAttribute.get(headerLabel);
+            if (attribute == null) {
+                throw new IllegalStateException(
+                        String.format("Unknown header label '%s': no attribute of %s maps to this label",
+                                headerLabel, valueType.getName()));
+            }
+            if (!consumed.add(attribute)) {
+                throw new IllegalStateException(
+                        String.format("Duplicate header label '%s' resolves to attribute '%s' "
+                                        + "which is already mapped by another column",
+                                headerLabel, attribute));
+            }
+            builder.addColumn(attribute);
+        }
+        return builder.build().withSkipFirstDataRow(true);
     }
 
     //TODO: see if it's possible to use a custom serialiser so we don't have to override the writer methods

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaCsvMapper.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaCsvMapper.java
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.rosetta.model.lib.functions.LabelProvider;
 import com.rosetta.model.lib.path.RosettaPath;
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
@@ -45,6 +47,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class RosettaCsvMapper extends CsvMapper  {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RosettaCsvMapper.class);
+
     private final CsvSchema defaultSchema;
     private final LabelProvider labelProvider;
 
@@ -101,6 +105,8 @@ public class RosettaCsvMapper extends CsvMapper  {
         CsvSchema schema = schemaFor(valueType);
         Map<String, String> labelToAttribute = new HashMap<>();
         boolean ambiguousLabels = false;
+        String duplicateLabel = null;
+        String duplicateAttribute = null;
         for (CsvSchema.Column column : schema) {
             String attribute = column.getName();
             String label = labelProvider.getLabel(RosettaPath.valueOf(attribute));
@@ -111,9 +117,14 @@ public class RosettaCsvMapper extends CsvMapper  {
                 // single attribute. Fall back to positional binding against the canonical
                 // schema order, which is the order the writer always emits columns in.
                 ambiguousLabels = true;
+                duplicateLabel = key;
+                duplicateAttribute = attribute;
             }
         }
         if (ambiguousLabels) {
+            LOGGER.warn("Ambiguous CSV label '{}' is shared by attribute '{}' and at least one other attribute of {}; "
+                            + "falling back to positional binding instead of label-based binding.",
+                    duplicateLabel, duplicateAttribute, valueType.getName());
             return buildPositionalReadSchema(valueType, schema, headerLabels);
         }
         CsvSchema.Builder builder = CsvSchema.builder();

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/csv/RosettaCsvMapperLabelledTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/csv/RosettaCsvMapperLabelledTest.java
@@ -262,16 +262,17 @@ public class RosettaCsvMapperLabelledTest {
     }
 
     // ---------------------------------------------------------------------------
-    // Test #9 — Duplicate labels on read → throws
+    // Test #9 — Duplicate labels on read → positional fallback
     // ---------------------------------------------------------------------------
 
     /**
-     * Unlike serialisation (test #5, which happily emits duplicate header text),
-     * deserialisation cannot disambiguate two attributes sharing the same label, so
-     * it must throw rather than silently mis-mapping a column.
+     * When two attributes share the same label the header text is ambiguous, so the reader
+     * cannot bind by name. Rather than fail, it falls back to positional binding against the
+     * type's canonical (alphabetical) schema order — the order the writer always emits — so a
+     * duplicate-labelled file the writer produced still round-trips correctly.
      */
     @Test
-    void shouldThrowWhenTwoColumnsShareTheSameLabelOnRead() {
+    void shouldFallBackToPositionalBindingWhenTwoColumnsShareTheSameLabelOnRead() throws JsonProcessingException {
         Map<String, String> labels = new HashMap<>();
         labels.put("firstName",  "Name");
         labels.put("identifier", "ID");
@@ -280,8 +281,36 @@ public class RosettaCsvMapperLabelledTest {
         LabelProvider provider = mapProvider(labels);
 
         RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper(provider);
-        String csv = "Name,ID,Name,\"User Name\"\n"
-                + "Alice,id-001,Smith,asmith\n";
+        User original = buildUser();
+        String csv = mapper.writeValueAsString(original);
+
+        User roundTripped = mapper.readValue(csv, User.class);
+        assertEquals(original, roundTripped);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test #11 — Duplicate labels + wrong column count → throws
+    // ---------------------------------------------------------------------------
+
+    /**
+     * The positional fallback only fires when the file is structurally consistent with the
+     * type. If duplicate labels force positional binding but the header column count does not
+     * match the schema, the file cannot be safely mapped by position and must throw rather
+     * than silently mis-align columns.
+     */
+    @Test
+    void shouldThrowWhenDuplicateLabelsForcePositionalBindingButColumnCountDiffers() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("firstName",  "Name");
+        labels.put("identifier", "ID");
+        labels.put("lastName",   "Name");   // duplicate label forces positional binding
+        labels.put("username",   "User Name");
+        LabelProvider provider = mapProvider(labels);
+
+        RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper(provider);
+        // User has four columns; this header has only three.
+        String csv = "Name,ID,Name\n"
+                + "Alice,id-001,Smith\n";
 
         assertThrows(IllegalStateException.class, () -> mapper.readValue(csv, User.class));
     }

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/csv/RosettaCsvMapperLabelledTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/csv/RosettaCsvMapperLabelledTest.java
@@ -21,6 +21,7 @@ package com.regnosys.rosetta.common.serialisation.csv;
  */
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.regnosys.rosetta.common.serialisation.RosettaCsvMapper;
 import com.rosetta.model.lib.functions.LabelProvider;
 import csv.test.user.User;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link RosettaCsvMapper} label-header behaviour (tests #1–5 from the plan).
@@ -180,5 +182,125 @@ public class RosettaCsvMapperLabelledTest {
         String expected = "Name,ID,Name,\"User Name\"\n"
                 + "Alice,id-001,Smith,asmith\n";
         assertEquals(expected, csv);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test #6 — Round-trip, all columns labelled
+    // ---------------------------------------------------------------------------
+
+    /**
+     * A CSV written with a fully-labelled provider must read back into an equal
+     * {@link User} using that same provider.
+     */
+    @Test
+    void shouldRoundTripWhenAllColumnsAreLabelled() throws JsonProcessingException {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("firstName",  "First Name");
+        labels.put("identifier", "ID");
+        labels.put("lastName",   "Last Name");
+        labels.put("username",   "User Name");
+        LabelProvider provider = mapProvider(labels);
+
+        RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper(provider);
+        User original = buildUser();
+        String csv = mapper.writeValueAsString(original);
+
+        User roundTripped = mapper.readValue(csv, User.class);
+        assertEquals(original, roundTripped);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test #7 — Round-trip, only some columns labelled (mixed fallback)
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Columns without a label fall back to the attribute name for both the header
+     * written and the header expected on read, so mixed labelling still round-trips.
+     */
+    @Test
+    void shouldRoundTripWhenOnlySomeColumnsAreLabelled() throws JsonProcessingException {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("firstName", "First Name");
+        labels.put("lastName",  "Last Name");
+        LabelProvider provider = mapProvider(labels);
+
+        RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper(provider);
+        User original = buildUser();
+        String csv = mapper.writeValueAsString(original);
+
+        User roundTripped = mapper.readValue(csv, User.class);
+        assertEquals(original, roundTripped);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test #8 — Header columns reordered
+    // ---------------------------------------------------------------------------
+
+    /**
+     * The reader must bind by column name (translated from label to attribute),
+     * not by position, so a hand-written CSV whose columns are in a different order
+     * to the type's schema order must still map values to the correct attributes.
+     */
+    @Test
+    void shouldMapValuesCorrectlyWhenHeaderColumnsAreReordered() throws JsonProcessingException {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("firstName",  "First Name");
+        labels.put("identifier", "ID");
+        labels.put("lastName",   "Last Name");
+        labels.put("username",   "User Name");
+        LabelProvider provider = mapProvider(labels);
+
+        RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper(provider);
+
+        // Schema order is firstName, identifier, lastName, username; here we deliberately
+        // reorder to: username, lastName, firstName, identifier.
+        String csv = "\"User Name\",\"Last Name\",\"First Name\",ID\n"
+                + "asmith,Smith,Alice,id-001\n";
+
+        User result = mapper.readValue(csv, User.class);
+        assertEquals(buildUser(), result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test #9 — Duplicate labels on read → throws
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Unlike serialisation (test #5, which happily emits duplicate header text),
+     * deserialisation cannot disambiguate two attributes sharing the same label, so
+     * it must throw rather than silently mis-mapping a column.
+     */
+    @Test
+    void shouldThrowWhenTwoColumnsShareTheSameLabelOnRead() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("firstName",  "Name");
+        labels.put("identifier", "ID");
+        labels.put("lastName",   "Name");   // duplicate label
+        labels.put("username",   "User Name");
+        LabelProvider provider = mapProvider(labels);
+
+        RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper(provider);
+        String csv = "Name,ID,Name,\"User Name\"\n"
+                + "Alice,id-001,Smith,asmith\n";
+
+        assertThrows(IllegalStateException.class, () -> mapper.readValue(csv, User.class));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test #10 — Regression: plain (no provider) read still works
+    // ---------------------------------------------------------------------------
+
+    /**
+     * With no {@link LabelProvider}, deserialisation must continue to work exactly as
+     * before: header row holds attribute names, columns bound by name.
+     */
+    @Test
+    void shouldDeserialisePlainCsvWhenNoProviderIsSupplied() throws JsonMappingException {
+        RosettaCsvMapper mapper = RosettaCsvMapper.createCsvObjectMapper();
+        String csv = "firstName,identifier,lastName,username\n"
+                + "Alice,id-001,Smith,asmith\n";
+
+        User result = mapper.readValue(csv, User.class);
+        assertEquals(buildUser(), result);
     }
 }


### PR DESCRIPTION
## Summary

`RosettaCsvMapper` could **serialise** with a `LabelProvider` — writing CSV headers as human-readable labels instead of attribute names — but could not read those files back. This PR adds label-aware deserialisation so labelled CSV round-trips.

## How it works

When a `LabelProvider` is set, on read the label header is translated back to attribute names **by name, not position**:

1. Build a `label → attributeName` map in one pass over `schemaFor(valueType)`, using the same `label != null ? label : attribute` fallback as the writer, so round-trips are symmetric.
2. Parse the incoming CSV header row, resolve each label to its attribute, and build a read schema with columns in the file's header order + `withSkipFirstDataRow(true)`.

This binds by name, so a file whose columns are **reordered** relative to the type's schema still maps values to the correct attributes.

When no provider is set, the original header-by-name path is untouched — plain CSV is byte-for-byte unchanged.

## Duplicate labels → guarded positional fallback

Two attributes can share a label, which makes the header text ambiguous (name-based binding is impossible). Rather than fail, the reader falls back to **positional binding against the type's canonical schema order** — the order the writer always emits columns in — so a duplicate-labelled file the writer produced still round-trips correctly.

This is guarded: if the header column count doesn't match the schema, the file is structurally unexpected (e.g. reordered or truncated) and cannot be safely mapped by position, so it throws `IllegalStateException` rather than silently mis-aligning columns.

> Known limitation: a file that is *both* reordered *and* duplicate-labelled with a matching column count is ambiguous by construction and will bind positionally without error. This is unavoidable — no method can recover it — and is the accepted cost of preferring recovery over fail-fast for the common case of round-tripping writer output.

## Files changed

- `common/.../serialisation/RosettaCsvMapper.java` — both `readValue(String,...)` and `readValue(URL,...)` overloads branch on `labelProvider`; new helpers `readHeaderLabels`, `buildLabelReadSchema`, and `buildPositionalReadSchema`. The URL overload reads the source into a String once to avoid opening the stream twice.
- `common/.../serialisation/csv/RosettaCsvMapperLabelledTest.java` — added round-trip tests: fully labelled, mixed labelled/fallback, reordered-header binding, duplicate-labels positional fallback, duplicate-labels column-count guard (throws), and a plain-CSV regression.

## Verification

`mvn test -pl common -Dtest=RosettaCsvMapperLabelledTest` (11/11), `mvn checkstyle:check -pl common` (0 violations).