### PR TITLE
Update DSL to 10.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>8</maven.compiler.release>
-        <rune.dsl.version>10.2.1</rune.dsl.version>
+        <rune.dsl.version>10.2.2</rune.dsl.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>


### PR DESCRIPTION
Updates the Rune DSL dependency to 10.2.2.

This picks up the DSL 10.2.2 release (fix for NPE when reading an attribute overridden to zero cardinality, finos/rune-dsl#1322).