### PR TITLE
Scope transform-mapper caching per format sensitivity; add clear() and defaultClassLoader() hooks

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/CachingTransformMapperFactory.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/CachingTransformMapperFactory.java
@@ -21,30 +21,40 @@ package com.regnosys.rosetta.common.serialisation;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rosetta.model.lib.transform.SerializationFormat;
 
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * A {@link TransformMapperFactory} decorator that builds each distinct {@link TransformSerialization}
- * once and caches it. Mapper construction is not cheap — Jackson module registration, and for XML a
- * full parse of the serialization config — while a runtime requests a mapper on every transform
- * execution, so implementors get per-instance reuse without writing any caching themselves.
+ * A {@link TransformMapperFactory} decorator that builds each distinct mapper once and caches it.
+ * Mapper construction is not cheap — Jackson module registration, and for XML a full parse of the
+ * serialization config — while a runtime requests a mapper on every transform execution, so
+ * implementors get per-instance reuse without writing any caching themselves.
+ * <p>
+ * The cache key pairs the {@link TransformSerialization} with the part of the function-class context
+ * the format is actually sensitive to, so equal serializations are shared exactly as widely as is
+ * correct:
+ * <ul>
+ *   <li>{@code CSV_LABELLED} — the function class itself: the labels derive from the function's
+ *       {@code @RuneLabelProvider}, so each labelled function gets (and reuses) its own mapper.</li>
+ *   <li>{@code RUNE_JSON} and {@code XML} — the function class's {@link ClassLoader}: these mappers
+ *       resolve model types against it, so functions from the same model share one mapper while
+ *       models in different classloaders never cross.</li>
+ *   <li>{@code JSON} and {@code CSV} — nothing: one mapper per factory.</li>
+ * </ul>
  * <p>
  * The cache lives and dies with this factory instance, and cached mappers may hold references into the
  * classloader they were built against. So the factory must be owned by the component whose model/
  * classloader scope it serves — one per model instance, one per test runner — and must <b>never</b> be
- * held statically, which would pin that classloader for the lifetime of the JVM.
- * <p>
- * {@code CSV_LABELLED} is deliberately not cached: its labels derive from the specific function class,
- * so a single serialization key cannot identify the mapper.
+ * held statically, which would pin that classloader for the lifetime of the JVM. An owner that replaces
+ * its model classloader in place (e.g. a workspace recompile) must call {@link #clear()} at that point,
+ * otherwise a stale mapper built against the discarded classloader can be served.
  */
 public class CachingTransformMapperFactory implements TransformMapperFactory {
 
     private final TransformMapperFactory delegate;
-    private final ConcurrentMap<TransformSerialization, ObjectMapper> cache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<CacheKey, ObjectMapper> cache = new ConcurrentHashMap<>();
 
     public CachingTransformMapperFactory(TransformMapperFactory delegate) {
         this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
@@ -52,9 +62,58 @@ public class CachingTransformMapperFactory implements TransformMapperFactory {
 
     @Override
     public ObjectMapper create(TransformSerialization serialization, Class<?> functionClass) {
-        if (serialization.getFormat() == SerializationFormat.CSV_LABELLED) {
-            return delegate.create(serialization, functionClass);
+        CacheKey key = new CacheKey(serialization, cacheScope(serialization, functionClass));
+        return cache.computeIfAbsent(key, k -> delegate.create(serialization, functionClass));
+    }
+
+    /**
+     * Drops every cached mapper, so the next request rebuilds against the delegate's current state.
+     * Call when the model classloader this factory serves is replaced in place.
+     */
+    public void clear() {
+        cache.clear();
+    }
+
+    /**
+     * The part of the function-class context that distinguishes cached mappers for the given
+     * serialization — see the class doc for the per-format rationale.
+     */
+    private static Object cacheScope(TransformSerialization serialization, Class<?> functionClass) {
+        switch (serialization.getFormat()) {
+            case CSV_LABELLED:
+                return functionClass;
+            case RUNE_JSON:
+            case XML:
+                return functionClass != null ? functionClass.getClassLoader() : null;
+            default:
+                return null;
         }
-        return cache.computeIfAbsent(serialization, key -> delegate.create(key, functionClass));
+    }
+
+    private static final class CacheKey {
+        private final TransformSerialization serialization;
+        private final Object scope;
+
+        private CacheKey(TransformSerialization serialization, Object scope) {
+            this.serialization = serialization;
+            this.scope = scope;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CacheKey)) {
+                return false;
+            }
+            CacheKey other = (CacheKey) o;
+            return serialization.equals(other.serialization) && Objects.equals(scope, other.scope);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(serialization, scope);
+        }
     }
 }

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/ClasspathTransformMapperFactory.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/ClasspathTransformMapperFactory.java
@@ -44,11 +44,10 @@ import java.util.Objects;
  * Suitable as-is wherever the model lives on the application classpath — tests, model builds, the
  * pipeline test-pack runner. Runtimes that load models in isolated, disposable classloaders should
  * <b>extend</b> this class rather than reimplement the per-format construction: the classloader-specific
- * concerns are isolated in two protected hooks — {@link #classLoader(Class)} (which loader resolves the
- * model types) and {@link #openXmlConfig(String, Class)} (where the XML config is looked up) — and
- * caching can be added by overriding {@link #create(TransformSerialization, Class)} to memoize around
- * {@code super.create(...)}. Everything else (which mapper implements which format, the
- * {@code CSV_LABELLED} label resolution) is inherited.
+ * concerns are isolated in protected hooks — {@link #defaultClassLoader()} (the model loader to use when
+ * no function class is resolvable) and {@link #openXmlConfig(String, Class)} (where the XML config is
+ * looked up) — and caching comes from wrapping in a {@link CachingTransformMapperFactory}. Everything
+ * else (which mapper implements which format, the {@code CSV_LABELLED} label resolution) is inherited.
  * <p>
  * For the {@code CSV_LABELLED} format the required {@link LabelProvider} is derived from the
  * {@code @RuneLabelProvider} annotation the Rune code generator places on the function class; when it
@@ -134,13 +133,23 @@ public class ClasspathTransformMapperFactory implements TransformMapperFactory {
     }
 
     /**
-     * The classloader against which serialization configs and model types resolve. The classpath
-     * implementation uses the function class's own loader; override for runtimes where the model
-     * classloader is owned elsewhere. May return {@code null}, which preserves the legacy Guava
-     * classpath-resource lookup and resolves model types against this library's loader.
+     * The classloader against which serialization configs and model types resolve: the function
+     * class's own loader, or {@link #defaultClassLoader()} when there is no function class. May return
+     * {@code null}, which preserves the legacy Guava classpath-resource lookup and resolves model
+     * types against this library's loader.
      */
     protected ClassLoader classLoader(Class<?> functionClass) {
-        return functionClass != null ? functionClass.getClassLoader() : null;
+        return functionClass != null ? functionClass.getClassLoader() : defaultClassLoader();
+    }
+
+    /**
+     * The classloader to fall back to when a mapper is requested without a resolvable function class.
+     * {@code null} here (the classpath default) preserves the legacy classpath lookup; runtimes that
+     * own the model classloader (an isolated, disposable loader per model) should override this — and
+     * usually only this — so function-less requests still resolve against their model.
+     */
+    protected ClassLoader defaultClassLoader() {
+        return null;
     }
 
     private ClassLoader resolveModelClassLoader(Class<?> functionClass) {

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/CachingTransformMapperFactoryTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/CachingTransformMapperFactoryTest.java
@@ -21,6 +21,10 @@ package com.regnosys.rosetta.common.serialisation;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rosetta.model.lib.annotations.RuneLabelProvider;
+import com.rosetta.model.lib.functions.LabelProvider;
+import com.rosetta.model.lib.functions.RosettaFunction;
+import com.rosetta.model.lib.path.RosettaPath;
 import com.rosetta.model.lib.transform.SerializationFormat;
 import org.junit.jupiter.api.Test;
 
@@ -43,9 +47,50 @@ class CachingTransformMapperFactoryTest {
     }
 
     @Test
-    void csvLabelledIsNotCached() {
+    void classInsensitiveFormatsShareOneMapperAcrossFunctions() {
+        TransformSerialization json = TransformSerialization.DEFAULT_JSON;
+        assertSame(factory.create(json, LabelledFunctionA.class), factory.create(json, LabelledFunctionB.class),
+                "a JSON mapper does not depend on the function class, so all functions share it");
+    }
+
+    @Test
+    void csvLabelledIsCachedPerFunctionClass() {
         TransformSerialization labelled = new TransformSerialization(SerializationFormat.CSV_LABELLED, null);
-        // labels derive from the function class, so each call constructs (here: unlabelled fallback)
-        assertNotSame(factory.create(labelled, null), factory.create(labelled, null));
+        ObjectMapper forA = factory.create(labelled, LabelledFunctionA.class);
+        assertSame(forA, factory.create(labelled, LabelledFunctionA.class),
+                "the same labelled function must reuse its cached mapper");
+        assertNotSame(forA, factory.create(labelled, LabelledFunctionB.class),
+                "labels derive from the function class, so another function must not share the mapper");
+    }
+
+    @Test
+    void classLoaderSensitiveFormatsShareOneMapperPerClassLoader() {
+        TransformSerialization runeJson = new TransformSerialization(SerializationFormat.RUNE_JSON, null);
+        assertSame(factory.create(runeJson, LabelledFunctionA.class), factory.create(runeJson, LabelledFunctionB.class),
+                "functions loaded by the same classloader must share one RUNE_JSON mapper");
+    }
+
+    @Test
+    void clearDropsEveryCachedMapper() {
+        TransformSerialization json = TransformSerialization.DEFAULT_JSON;
+        ObjectMapper before = factory.create(json, null);
+        factory.clear();
+        assertNotSame(before, factory.create(json, null),
+                "after clear() the mapper must be rebuilt, not served from the stale cache");
+    }
+
+    public static class TestLabelProvider implements LabelProvider {
+        @Override
+        public String getLabel(RosettaPath path) {
+            return path.toString();
+        }
+    }
+
+    @RuneLabelProvider(labelProvider = TestLabelProvider.class)
+    private abstract static class LabelledFunctionA implements RosettaFunction {
+    }
+
+    @RuneLabelProvider(labelProvider = TestLabelProvider.class)
+    private abstract static class LabelledFunctionB implements RosettaFunction {
     }
 }

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/ClasspathTransformMapperFactoryTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/ClasspathTransformMapperFactoryTest.java
@@ -173,4 +173,20 @@ class ClasspathTransformMapperFactoryTest {
                         ClasspathTransformMapperFactoryTest.class));
         assertTrue(e.getMessage().contains("does/not/exist.json"));
     }
+
+    @Test
+    void functionLessRequestsResolveAgainstTheOverriddenDefaultClassLoader() {
+        // A runtime owning the model classloader overrides defaultClassLoader() so that requests
+        // without a resolvable function class (e.g. a legacy pipeline definition) still resolve
+        // the XML config against the model rather than the application classpath.
+        ClassLoader modelClassLoader = ClasspathTransformMapperFactoryTest.class.getClassLoader();
+        ClasspathTransformMapperFactory modelOwned = new ClasspathTransformMapperFactory() {
+            @Override
+            protected ClassLoader defaultClassLoader() {
+                return modelClassLoader;
+            }
+        };
+        ObjectMapper mapper = modelOwned.create(new TransformSerialization(SerializationFormat.XML, XML_CONFIG), null);
+        assertInstanceOf(XmlMapper.class, mapper);
+    }
 }


### PR DESCRIPTION
# Description

Consuming the `TransformMapperFactory` seam from an isolated-classloader runtime (rosetta-products' `JarModelInstance`, see REGnosys/rosetta-products#6845) currently requires working around three gaps. This PR closes them so consumers can stop hand-rolling the workarounds.

## 1. `CachingTransformMapperFactory`: cache what each format is actually sensitive to

The cache was keyed on `TransformSerialization` alone, which forced two compromises:

- **CSV_LABELLED was not cacheable at all** (the labels derive from the function's `@RuneLabelProvider`, which the key couldn't see), so a labelled mapper was rebuilt on every transform execution.
- **RUNE_JSON/XML were cached with the first caller's classloader baked in** — correct only while every function happens to share one loader; wrong the moment two models in different classloaders hit the same factory.

The key now pairs the serialization with the part of the function-class context the format is sensitive to:

| Format | Cache scope |
|---|---|
| `CSV_LABELLED` | the function class (labels are per function) |
| `RUNE_JSON`, `XML` | the function class's `ClassLoader` (model-type resolution) |
| `JSON`, `CSV` | none — one mapper per factory |

So labelled mappers are now cached (once per function), and equal serializations are shared exactly as widely as is correct.

## 2. `CachingTransformMapperFactory.clear()`

Cached mappers hold references into the classloader they were built against. A runtime that replaces its model classloader *in place* (a workspace recompile) previously had to throw the whole factory away and rebuild it; `clear()` lets it keep a final field and invalidate at the swap point instead.

## 3. `ClasspathTransformMapperFactory.defaultClassLoader()`

`classLoader(Class)` returned `null` when no function class is resolvable, so isolated-classloader runtimes had to override `classLoader(...)` and re-state the base logic just to change the null-case fallback. The new `defaultClassLoader()` hook isolates exactly that decision — such runtimes now override one trivial method and inherit the rest.

## Compatibility

- `create(...)` signatures and per-format construction are unchanged; subclasses overriding `classLoader(Class)` wholesale behave exactly as before.
- The only observable behaviour changes are mapper identity/reuse: CSV_LABELLED is now reused per function class (previously fresh every call), and RUNE_JSON/XML are no longer shared across classloaders (previously first-caller-wins).

## Tests

`CachingTransformMapperFactoryTest` covers the per-format cache scopes and `clear()`; `ClasspathTransformMapperFactoryTest` covers the `defaultClassLoader()` fallback. Full `common` module test suite passes.
