### PR TITLE
[11.x.x] Backport missing serialization fixes from main

### DIFF
--- a/serialization/src/main/java/org/finos/rune/mapper/RuneJsonObjectMapper.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/RuneJsonObjectMapper.java
@@ -36,7 +36,6 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import com.google.common.annotations.Beta;
 import com.rosetta.model.lib.RosettaModelObject;
 import org.finos.rune.mapper.date.RuneDateModule;
 import org.finos.rune.mapper.filters.SubtypeFilter;
@@ -70,7 +69,6 @@ import java.util.List;
  *
  * @see ObjectMapper
  */
-@Beta
 public class RuneJsonObjectMapper extends ObjectMapper {
     public RuneJsonObjectMapper() {
         super(create());

--- a/serialization/src/main/java/org/finos/rune/mapper/RuneJsonObjectMapper.java
+++ b/serialization/src/main/java/org/finos/rune/mapper/RuneJsonObjectMapper.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -105,6 +107,9 @@ public class RuneJsonObjectMapper extends ObjectMapper {
                 .setFilterProvider(new SimpleFilterProvider().addFilter("SubtypeFilter", new SubtypeFilter()))
                 .addMixIn(RosettaModelObject.class, RosettaModelObjectMixin.class)
                 .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
-                .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.PUBLIC_ONLY);
+                .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.PUBLIC_ONLY)
+                // Always pretty print with "\n": serialised documents are stored and
+                // compared across operating systems
+                .setDefaultPrettyPrinter(new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", "\n")));
     }
 }

--- a/serialization/src/test/java/org/finos/rune/serialization/RuneSerializerTestHelper.java
+++ b/serialization/src/test/java/org/finos/rune/serialization/RuneSerializerTestHelper.java
@@ -44,6 +44,7 @@ import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -102,7 +103,7 @@ public class RuneSerializerTestHelper {
 
     public static String readAsString(Path jsonPath) {
         try {
-            return new String(Files.readAllBytes(jsonPath));
+            return new String(Files.readAllBytes(jsonPath), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
## Summary

Audited `serialization/` on `main` vs `11.x.x` for missing backports. Most main-track commits touching `serialization/` are either DSL 10.x migration commits (out of scope — `11.x.x` tracks a separate DSL fork on 9.85.1) or were already backported previously under different PR numbers (#599, #607, #610, #623, #626, #629). Two genuine gaps were found and are backported here:

- **Pin LF pretty printing and UTF-8 fixture reads** — cherry-picked the `serialization/`-scoped portion of #675 (`bd42f30`). That commit also touched `common/`, CI workflows, and bumped the DSL version on main; only the `RuneJsonObjectMapper` pretty-printer pin and the UTF-8 fixture read fix apply here.
- **Remove `@Beta` annotation from `RuneJsonObjectMapper`** — this was bundled into #619 ("Update to DSL 10.0.0-dev.13", `92f306c`) despite being unrelated to the DSL bump.

## Test plan
- [x] `mvn -pl serialization -am test` passes (65 tests, 0 failures)