### PR TITLE
[11.x.x] - fix: Windows compatibility — pin LF pretty printing, UTF-8 fixture reads (#675)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Sources and test fixtures are stored with LF and some tests compare fixture
+# files byte-for-byte against generated output, so check them out with LF on
+# every platform (overrides core.autocrlf on Windows).
+* text=auto eol=lf
+# JAR manifests use CRLF per the JAR specification; leave this fixture as is.
+*.MF -text

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,38 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-on-ubuntu:
+    name: Maven Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package
+
+  build-on-windows:
+    name: Maven Build on Windows
+    runs-on: windows-latest
+    steps:
+    - name: Enable git long paths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -118,8 +118,9 @@
                                 <sourceRoot>${project.basedir}/src/test/resources/serialisation/xml/rosetta</sourceRoot>
                                 <sourceRoot>${project.basedir}/src/test/resources/serialisation/json/rosetta</sourceRoot>
                             </sourceRoots>
-                            <!-- Matches the Rosetta lib jar file from the class path - this is used to get the basictype and annotations.rosetta files -->
-                            <classPathLookupFilter>(.*)(org/finos/rune/)(rune-runtime)/(.*)/(.*)\.jar</classPathLookupFilter>
+                            <!-- Matches the Rosetta lib jar file from the class path - this is used to get the basictype and annotations.rosetta files.
+                                 The separator alternation [/\\] keeps the filter working on Windows, where classpath entries use backslashes. -->
+                            <classPathLookupFilter>(.*)(org[/\\]finos[/\\]rune[/\\])(rune-runtime)[/\\](.*)[/\\](.*)\.jar</classPathLookupFilter>
                             <languages>
                                 <language>
                                     <setup>com.regnosys.rosetta.RosettaStandaloneSetup</setup>

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaObjectMapperCreator.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/RosettaObjectMapperCreator.java
@@ -24,10 +24,15 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.regnosys.rosetta.common.serialisation.xml.RosettaXmlMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -144,6 +149,26 @@ public class RosettaObjectMapperCreator implements ObjectMapperCreator {
 
                 .setVisibility(PropertyAccessor.ALL, Visibility.PUBLIC_ONLY);
 
+        PrettyPrinter prettyPrinter = platformIndependentPrettyPrinter(mapper);
+        if (prettyPrinter != null) {
+            mapper.setDefaultPrettyPrinter(prettyPrinter);
+        }
         return mapper;
+    }
+
+    /**
+     * Jackson's default pretty printers separate lines with the platform line separator.
+     * Serialised documents are stored and compared across operating systems, so pretty
+     * printing always uses "\n". CSV is left alone: its line separator comes from the
+     * {@code CsvSchema}, which already defaults to "\n".
+     */
+    private static PrettyPrinter platformIndependentPrettyPrinter(ObjectMapper mapper) {
+        if (mapper instanceof CsvMapper) {
+            return null;
+        }
+        if (mapper instanceof XmlMapper) {
+            return new DefaultXmlPrettyPrinter().withCustomNewLine("\n");
+        }
+        return new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", "\n"));
     }
 }

--- a/common/src/test/java/com/regnosys/rosetta/common/compile/JavaCSourceCancellableCompilerTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/compile/JavaCSourceCancellableCompilerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import javax.tools.JavaCompiler;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -162,7 +163,12 @@ class JavaCSourceCancellableCompilerTest {
         ArrayList<Path> javaSourcePaths = new ArrayList<>();
         ClassLoader classLoader = getClass().getClassLoader();
         for (String javaFile : javaFiles) {
-            File file = new File(Objects.requireNonNull(classLoader.getResource(String.format("%s/%s", TEST_RESOURCES, javaFile))).getFile());
+            File file;
+            try {
+                file = new File(Objects.requireNonNull(classLoader.getResource(String.format("%s/%s", TEST_RESOURCES, javaFile))).toURI());
+            } catch (URISyntaxException e) {
+                throw new IOException(e);
+            }
             Path target = input.resolve(javaFile);
             Files.copy(file.toPath(), target);
             javaSourcePaths.add(target);

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/json/RosettaSerialisationTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/json/RosettaSerialisationTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -277,8 +278,8 @@ class RosettaSerialisationTest {
     void overriddenAttributesOrderIsPreserved() throws IOException {
         ObjectMapper mapper = RosettaObjectMapper.getNewRosettaObjectMapper();
         Path path = Paths.get("src/test/java/com/regnosys/rosetta/common/serialisation/json/ordering/ordering.rosetta");
-        String rosetta = new String(Files.readAllBytes(path));
-        String foo2 =  new String(Files.readAllBytes(Paths.get("src/test/java/com/regnosys/rosetta/common/serialisation/json/ordering/ordering-foo2.json")));
+        String rosetta = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+        String foo2 = new String(Files.readAllBytes(Paths.get("src/test/java/com/regnosys/rosetta/common/serialisation/json/ordering/ordering-foo2.json")), StandardCharsets.UTF_8);
 
         assertSerialisationRoundTrip(rosetta, mapper, foo2, "serialization.test.passing.ordering.Root");
     }

--- a/common/src/test/java/com/regnosys/rosetta/common/transform/PipelineSerialisationTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/transform/PipelineSerialisationTest.java
@@ -21,6 +21,8 @@ package com.regnosys.rosetta.common.transform;
  */
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PipelineSerialisationTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+  // Pretty printing is pinned to "\n" (as in RosettaObjectMapperCreator) so the
+  // round-trip matches the LF fixture files on every platform
+  private final ObjectMapper objectMapper = new ObjectMapper()
+      .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+      .setDefaultPrettyPrinter(new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", "\n")));
 
   @Test
   void pipelineProjectionEmirTradeValid() throws IOException {

--- a/common/src/test/java/com/regnosys/rosetta/common/transform/TestPackSerialisationTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/transform/TestPackSerialisationTest.java
@@ -21,6 +21,8 @@ package com.regnosys.rosetta.common.transform;
  */
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestPackSerialisationTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+  // Pretty printing is pinned to "\n" (as in RosettaObjectMapperCreator) so the
+  // round-trip matches the LF fixture files on every platform
+  private final ObjectMapper objectMapper = new ObjectMapper()
+      .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+      .setDefaultPrettyPrinter(new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", "\n")));
 
   @Test
   void testPackProjectionEmirTradeCommodity() throws IOException {

--- a/common/src/test/java/com/regnosys/rosetta/common/util/ResourceUtils.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/util/ResourceUtils.java
@@ -27,13 +27,14 @@ import com.rosetta.model.lib.RosettaModelObject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 public class ResourceUtils {
 
     public static String readAsString(Path jsonPath) {
         try {
-            return new String(Files.readAllBytes(jsonPath));
+            return new String(Files.readAllBytes(jsonPath), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Backport of #675 (`bd42f3038` on `main`) to the `11.x.x` line.

## What it contains

- **`RosettaObjectMapperCreator`** — pin the JSON/XML pretty printers to `\n`. Jackson's defaults use the platform line separator, so pretty-printed documents differed between Windows and unix. CSV is untouched (`CsvSchema` already defaults to `\n`).
- **`PipelineSerialisationTest` / `TestPackSerialisationTest`** — same pin locally, since these build plain `ObjectMapper`s that the central pin does not cover.
- **UTF-8 fixture reads** (`RosettaSerialisationTest`, `ResourceUtils`) — the build targets Java 8, where the default charset is platform-dependent (Cp1252 on Windows).
- **`JavaCSourceCancellableCompilerTest`** — resolve test resources via `URL.toURI()` instead of `URL.getFile()`, which breaks on paths containing spaces.
- **`common/pom.xml` `classPathLookupFilter`** — accept either path separator, so the rune-runtime jar is found on Windows classpaths.
- **`.gitattributes`** — pin LF checkout on every platform.
- **`.github/workflows/check-pr.yml`** — PR checks on Ubuntu and Windows.

## Backport notes

Cherry-picked with `-x`. One conflict in the root `pom.xml`, resolved by **keeping the `11.x.x` value of `rune.dsl.version`**.

Upstream, this commit also bumped `rune.dsl.version` to 10.2.3 to pick up the DSL-side Windows fixes (finos/rune-dsl#1324). The 9.x equivalent is not released yet — finos/rune-dsl#1338 is the corresponding DSL backport. Once that is merged and a 9.x DSL release is cut, the version bump should flow through the normal bundle DSL update, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)