### PR TITLE
feat: add a shared LineEndings.normalise utility

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/util/LineEndings.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/util/LineEndings.java
@@ -1,0 +1,48 @@
+package com.regnosys.rosetta.common.util;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2024 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============
+ */
+
+import java.util.Optional;
+
+/**
+ * Line ending normalisation for content that is written on one operating system
+ * and compared on another.
+ * <p>
+ * Serialised documents are pinned to "\n" when they are produced, but expectation
+ * files committed to a repository without a {@code .gitattributes} still check out
+ * with CRLF on Windows. Comparing produced output against such a file therefore has
+ * to normalise both sides, otherwise the comparison comes down to which operating
+ * system the file was checked out on.
+ */
+public class LineEndings {
+
+    private LineEndings() {
+    }
+
+    /**
+     * Converts CRLF and lone CR line endings to "\n". Returns null for null input.
+     */
+    public static String normalise(String str) {
+        return Optional.ofNullable(str)
+                .map(s -> s.replace("\r\n", "\n").replace("\r", "\n"))
+                .orElse(null);
+    }
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/util/LineEndingsTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/util/LineEndingsTest.java
@@ -1,0 +1,61 @@
+package com.regnosys.rosetta.common.util;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2024 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LineEndingsTest {
+
+    @Test
+    void crlfIsNormalisedToLf() {
+        assertEquals("a\nb\nc", LineEndings.normalise("a\r\nb\r\nc"));
+    }
+
+    @Test
+    void loneCarriageReturnIsNormalisedToLf() {
+        assertEquals("a\nb", LineEndings.normalise("a\rb"));
+    }
+
+    @Test
+    void lfIsLeftUnchanged() {
+        assertEquals("a\nb\nc", LineEndings.normalise("a\nb\nc"));
+    }
+
+    @Test
+    void contentWithoutLineBreaksIsLeftUnchanged() {
+        assertEquals("abc", LineEndings.normalise("abc"));
+    }
+
+    @Test
+    void nullIsReturnedForNull() {
+        assertNull(LineEndings.normalise(null));
+    }
+
+    @Test
+    void aCrlfDocumentAndAnLfDocumentNormaliseToTheSameValue() {
+        String lf = "{\n  \"a\" : 1\n}";
+        String crlf = "{\r\n  \"a\" : 1\r\n}";
+        assertEquals(LineEndings.normalise(lf), LineEndings.normalise(crlf));
+    }
+}


### PR DESCRIPTION
First of two PRs restoring backwards compatibility for downstream repositories after the Windows-compatibility work (#675 and finos/rune-dsl#1324). Follow-up in rune-testing depends on this one.

## Background — the regression this addresses

#675 pinned `RosettaObjectMapperCreator` and `RuneJsonObjectMapper` pretty printing to `"\n"`. Previously they used Jackson's default, which is `System.lineSeparator()`. Verified directly against the published jars, with a Windows line separator:

```
serialization 12.3.1 (pre-fix)  → output line ending: CRLF
serialization 12.3.2 (post-fix) → output line ending: LF
```

That is correct in itself — LF-canonical artifacts are deterministic. But it is a breaking change for any consumer on Windows:

- **before** — expectation file checked out CRLF (no `.gitattributes`, `core.autocrlf=true`), serialiser emitted CRLF → **matched**
- **after** — expectation file still CRLF, serialiser emits LF → **mismatch**

Reproduced in the CDM, which compares with a raw `assertEquals(expectedJson, actualJson)` in `FunctionInputCreationTest.assertResult` and has neither a `.gitattributes` nor any line-ending normalisation. The CDM builds clean on macOS/Linux against both the old and new versions — the breakage only appears on Windows, which is why it was not caught here.

The repos changed by the Windows work each got a `.gitattributes` in the same commit, so they are internally consistent. Consumers did not, so the incompatibility landed downstream.

## This change

Adds `com.regnosys.rosetta.common.util.LineEndings`, so normalisation lives on the dependency path every consumer already has. Until now the only helper was `TestingExpectationUtil.normaliseLineEndings` in rune-testing, which most consumers do not depend on and which is test-infrastructure rather than a general utility.

`normalise` converts CRLF and lone CR to `"\n"`, and is null-safe. Six unit tests cover the cases, including that a CRLF and an LF document normalise to the same value.

## Follow-up

rune-testing will delegate `normaliseLineEndings` to this helper and normalise expectation reads at the source, so a CRLF checkout behaves like an LF one without every downstream assertion having to change. That PR needs the `0.0.0.main-SNAPSHOT` published from this one, so it goes second.

Note for reviewers: `TestingExpectationUtil.normaliseLineEndings` currently strips `\r` outright, which joins lines for lone-CR content; `LineEndings.normalise` converts it to a newline instead. The two differ only for lone-CR input, which no JSON/XML expectation file realistically contains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)