### PR TITLE
[11.x.x] - feat: add a shared LineEndings.normalise utility

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/util/LineEndings.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/util/LineEndings.java
@@ -1,0 +1,48 @@
+package com.regnosys.rosetta.common.util;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2024 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============
+ */
+
+import java.util.Optional;
+
+/**
+ * Line ending normalisation for content that is written on one operating system
+ * and compared on another.
+ * <p>
+ * Serialised documents are pinned to "\n" when they are produced, but expectation
+ * files committed to a repository without a {@code .gitattributes} still check out
+ * with CRLF on Windows. Comparing produced output against such a file therefore has
+ * to normalise both sides, otherwise the comparison comes down to which operating
+ * system the file was checked out on.
+ */
+public class LineEndings {
+
+    private LineEndings() {
+    }
+
+    /**
+     * Converts CRLF and lone CR line endings to "\n". Returns null for null input.
+     */
+    public static String normalise(String str) {
+        return Optional.ofNullable(str)
+                .map(s -> s.replace("\r\n", "\n").replace("\r", "\n"))
+                .orElse(null);
+    }
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/util/LineEndingsTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/util/LineEndingsTest.java
@@ -1,0 +1,61 @@
+package com.regnosys.rosetta.common.util;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2024 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LineEndingsTest {
+
+    @Test
+    void crlfIsNormalisedToLf() {
+        assertEquals("a\nb\nc", LineEndings.normalise("a\r\nb\r\nc"));
+    }
+
+    @Test
+    void loneCarriageReturnIsNormalisedToLf() {
+        assertEquals("a\nb", LineEndings.normalise("a\rb"));
+    }
+
+    @Test
+    void lfIsLeftUnchanged() {
+        assertEquals("a\nb\nc", LineEndings.normalise("a\nb\nc"));
+    }
+
+    @Test
+    void contentWithoutLineBreaksIsLeftUnchanged() {
+        assertEquals("abc", LineEndings.normalise("abc"));
+    }
+
+    @Test
+    void nullIsReturnedForNull() {
+        assertNull(LineEndings.normalise(null));
+    }
+
+    @Test
+    void aCrlfDocumentAndAnLfDocumentNormaliseToTheSameValue() {
+        String lf = "{\n  \"a\" : 1\n}";
+        String crlf = "{\r\n  \"a\" : 1\r\n}";
+        assertEquals(LineEndings.normalise(lf), LineEndings.normalise(crlf));
+    }
+}


### PR DESCRIPTION
Backport of #687 to the `11.x.x` line. Cherry-picked with `-x`, applied cleanly, no changes from `main`.

## Why

The Windows-compatibility work pinned pretty printing to `"\n"` where it previously followed `System.lineSeparator()`. Verified against the published jars under a Windows line separator:

```
serialization 12.3.1 (pre-fix)  → CRLF
serialization 12.3.2 (post-fix) → LF
```

Right in itself, but breaking for consumers on Windows: an expectation file with no `.gitattributes` checks out CRLF, matched the old CRLF output, and no longer matches the new LF output. Reproduced in the CDM, which compares with a bare `assertEquals` and has neither a `.gitattributes` nor any normalisation.

The 11.x line carries the same defect via #686, released in bundle 11.125.0.

## This change

Adds `com.regnosys.rosetta.common.util.LineEndings.normalise(String)` — null-safe, CRLF and lone CR to `"\n"` — so normalisation sits on the dependency path every consumer already has. 6 unit tests. Verified locally on this branch: build succeeds, all 6 pass.

## Merge order

This one first: the rune-testing `11.x.x` backport consumes `LineEndings` as `0.0.0.11.x.x-SNAPSHOT` and stays red until this merges and republishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)