### PR TITLE
Modernise CVE scanning workflow on 11.x.x to match main

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     # Run daily to catch newly published CVEs even without repo changes.
-    - cron: '0 3 * * *'
+    # Staggered across repos (rune-dsl 01:00, rune-common 01:30, rune-testing
+    # 02:00) to avoid all three hitting the NVD API / shared runners at once.
+    - cron: '30 1 * * *'
   push:
     branches:
       - 11.x.x

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,9 +2,12 @@ name: CVE Scanning
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run daily to catch newly published CVEs even without repo changes.
+    - cron: '0 3 * * *'
   push:
     branches:
-      - main
+      - 11.x.x
     paths:
       - 'pom.xml'
       - 'CVE-suppressions.xml'
@@ -22,27 +25,110 @@ concurrency:
 
 jobs:
   depcheck:
+    # Fork PRs don't get repo secrets, so NVD_API_KEY would be empty and fail
+    # confusingly. Skip the job for fork PRs; other triggers (push, schedule,
+    # dispatch, same-repo PRs) are unaffected.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/maven-build
-      with:
-        run-tests: false
-    - name: CVE scanning
-      uses: dependency-check/Dependency-Check_Action@main
-      env:
-        JAVA_HOME: /opt/jdk
-      with:
-        project: ${{github.repository}}
-        path: '.'
-        format: 'HTML'
-        out: 'reports'
-        args: >
-          --suppression CVE-suppressions.xml
-          --failOnCVSS 7
-          --centralUrl https://central.sonatype.com/solrsearch/select # remove when https://search.maven.org/solrsearch/select is back online
-    - name: Upload results
-      uses: actions/upload-artifact@v4
-      with:
-        name: CVE Scan Report
-        path: ${{github.workspace}}/reports
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/maven-build
+        with:
+          run-tests: false
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      # Persists the NVD dataset across runs, keyed by date, so runs resume
+      # instead of re-downloading. Split into restore/save (instead of the
+      # combined actions/cache action) because its save step only runs on job
+      # success, and the scan step below is expected to fail on a real CVSS>=7
+      # finding.
+      - name: Restore NVD data cache
+        id: nvd-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .dependency-check-data
+          key: nvd-data-${{ steps.date.outputs.date }}
+          restore-keys: |
+            nvd-data-
+      # A partial download doesn't advance dependency-check's checkpoint, so a
+      # timed-out run just re-requests the same delta (upstream
+      # dependency-check#7180). A separate step with a large timeout lets the
+      # update eventually complete without blocking the scan below.
+      - name: Update NVD data
+        id: nvd-update
+        timeout-minutes: 300 # stay under the 360-minute GitHub-hosted runner job cap
+        continue-on-error: true
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          mvn -B org.owasp:dependency-check-maven:12.2.2:update-only \
+            -DdataDirectory="${PWD}/.dependency-check-data" \
+            -DnvdApiKeyEnvironmentVariable=NVD_API_KEY \
+            -DnvdApiDelay=6000 \
+            -DnvdMaxRetryCount=30 \
+            -DnvdApiResultsPerPage=1000
+      # Saved right after the update, before the scan, so data is kept even
+      # if scanning fails. always() also covers the update step timing out,
+      # since partial data is still worth keeping.
+      - name: Save NVD data cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .dependency-check-data
+          key: nvd-data-${{ steps.date.outputs.date }}
+      # Scans against whatever NVD data is already cached (autoUpdate=false),
+      # so this step stays fast and isn't blocked by a flaky/slow sync.
+      - name: CVE scanning
+        id: cve-scanning
+        run: |
+          mvn -B org.owasp:dependency-check-maven:12.2.2:aggregate \
+            -Dname="Rune Common" \
+            -DdataDirectory="${PWD}/.dependency-check-data" \
+            -DautoUpdate=false \
+            -DsuppressionFiles=CVE-suppressions.xml \
+            -Dformats=HTML \
+            -DoutputDirectory=reports \
+            -DfailBuildOnCVSS=7 \
+            -DossIndexAnalyzerEnabled=false \
+            -DnodeAuditAnalyzerEnabled=false
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: CVE Scan Report
+          path: reports
+      - name: Note if the NVD update did not complete
+        if: steps.nvd-update.outcome == 'failure'
+        run: |
+          echo "::warning::The 'Update NVD data' step did not complete (see its log for details)."
+          if [ "${{ steps.cve-scanning.outcome }}" = "failure" ]; then
+            echo "::warning::The scan step also failed - if that failure is a NoDataException there is no cached NVD data yet (e.g. first ever run); otherwise it is likely a real CVSS>=7 finding, see the report artifact."
+          else
+            echo "::warning::The scan step still succeeded, using the last previously cached NVD data - it may be a few days stale until an update fully completes."
+          fi
+      # Notify Slack if the scan itself failed (e.g. a real CVSS>=7 finding),
+      # so the team doesn't have to check the Actions tab. Restricted to the
+      # scheduled cron run so manual/PR/push triggers don't spam the channel.
+      - name: Notify Slack on scan failure
+        if: failure() && steps.cve-scanning.outcome == 'failure' && github.event_name == 'schedule'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
+        run: |
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"text\": \":rotating_light: *CVE Scanning* failed for \`${{ github.repository }}\` on \`${{ github.head_ref || github.ref_name }}\` (triggered by \`${{ github.event_name }}\`).\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+            }" \
+            "$SLACK_WEBHOOK_URL"
+      # Also notify Slack on success for the scheduled run, so the team has
+      # positive confirmation that the daily scan is running and clean.
+      - name: Notify Slack on scan success
+        if: success() && github.event_name == 'schedule'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
+        run: |
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"text\": \":white_check_mark: *CVE Scanning* passed for \`${{ github.repository }}\` on \`${{ github.head_ref || github.ref_name }}\`.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+            }" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Brings the 11.x.x branch's cve-scanning.yml in line with main: switches from the unmaintained dependency-check/Dependency-Check_Action to the Maven dependency-check plugin with NVD data caching, adds a daily scheduled run, and adds Slack notifications restricted to scheduled runs (failure alert plus a success confirmation), matching REGnosys/rosetta-code-generators#570/#571.

Please include a summary of the change and the issue/story number.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
