### PR TITLE
[11.x.x] Update to DSL 9.88.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>8</maven.compiler.release>
-        <rune.dsl.version>9.87.0</rune.dsl.version>
+        <rune.dsl.version>9.88.0</rune.dsl.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>


### PR DESCRIPTION
Bump `rune.dsl.version` to 9.88.0 as part of bundle release 11.128.0.