### PR TITLE
Update to DSL 10.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>8</maven.compiler.release>
-        <rune.dsl.version>10.5.0</rune.dsl.version>
+        <rune.dsl.version>10.5.1</rune.dsl.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>


### PR DESCRIPTION
Picks up [rune-dsl 10.5.1](https://github.com/finos/rune-dsl/releases/tag/10.5.1), which fixes the setup's Rune config wiring being dropped by any custom Xtext setup that overrides `createInjector()` ([#1355](https://github.com/finos/rune-dsl/pull/1355)).