### PR TITLE
[11.x.x] Update to DSL 9.88.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>8</maven.compiler.release>
-        <rune.dsl.version>9.88.0</rune.dsl.version>
+        <rune.dsl.version>9.88.1</rune.dsl.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>


### PR DESCRIPTION
Picks up [rune-dsl 9.88.1](https://github.com/finos/rune-dsl/releases/tag/9.88.1), the 9.x.x backport of the fix for the setup's Rune config wiring being dropped by any custom Xtext setup that overrides `createInjector()` ([#1357](https://github.com/finos/rune-dsl/pull/1357)).